### PR TITLE
Add tests and module functions

### DIFF
--- a/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
+++ b/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="TaskSeq.Tests.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="2.13.0" />
+    <PackageReference Include="FsUnit.xUnit" Version="5.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FSharpy.TaskSeq\FSharpy.TaskSeq.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/FSharpy.TaskSeq.Test/Program.fs
+++ b/src/FSharpy.TaskSeq.Test/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.fs
@@ -1,0 +1,247 @@
+module Tests
+
+open System
+
+open System.Threading.Tasks
+
+open FsToolkit.ErrorHandling
+open FsUnit.Xunit
+open FSharpy
+open Xunit
+
+[<AutoOpen>]
+module Internal =
+    /// Creates dummy tasks with a randomized delay and a mutable state,
+    /// to ensure we properly test whether processing is done ordered or not.
+    type TaskFactory() =
+        let mutable x = 0
+        let rnd = Random()
+        let rnd () = rnd.Next(10, 30)
+
+        let runTask i = backgroundTask {
+            // ensure unequal running lengths and points-in-time for assigning the variable
+            let! _ = Task.Delay(rnd ())
+            x <- x + 1
+            return x // this dereferences the variable
+        }
+
+        member _.createBunchOfTasks total = [
+            for i in 0 .. total - 1 do
+                fun () -> runTask i
+        ]
+
+    let joinWithContinuation tasks =
+        let simple (t: unit -> Task<_>) (source: unit -> Task<_>) : unit -> Task<_> =
+            fun () ->
+                source()
+                    .ContinueWith((fun (_: Task) -> t ()), TaskContinuationOptions.OnlyOnRanToCompletion)
+                    .Unwrap()
+                :?> Task<_>
+
+        let rec combine acc (tasks: (unit -> Task<_>) list) =
+            match tasks with
+            | [] -> acc
+            | t :: tail -> combine (simple t acc) tail
+
+        match tasks with
+        | first :: rest -> combine first rest
+        | [] -> failwith "oh oh, no tasks given!"
+
+    let joinIdentityHotStarted tasks () = task { return tasks |> List.map (fun t -> t ()) }
+
+    let joinIdentityDelayed tasks () = task { return tasks }
+
+    let createAndJoinMultipleTasks total joiner : Task<_> =
+        // the actual creation of tasks
+        let tasks = TaskFactory().createBunchOfTasks total
+        let combinedTask = joiner tasks
+        // start the combined tasks
+        combinedTask ()
+
+module TaskSeqTests =
+    let createAsyncEnum count =
+        let tasks = TaskFactory().createBunchOfTasks count
+
+        taskSeq {
+            for task in tasks do
+                // cannot use `yield!` here, as `taskSeq` expects it to return a seq
+                let! x = task ()
+                yield x
+        }
+
+    [<Fact>]
+    let ``TaskSeq-iteriAsync should go over all items`` () = task {
+        let tq = createAsyncEnum 10
+        let mutable sum = 0
+        do! tq |> TaskSeq.iteriAsync (fun i _ -> sum <- sum + i)
+        sum |> should equal 45 // index starts at 0
+    }
+
+    [<Fact>]
+    let ``TaskSeq-iterAsync should go over all items`` () = task {
+        let tq = createAsyncEnum 10
+        let mutable sum = 0
+        do! tq |> TaskSeq.iterAsync (fun item -> sum <- sum + item)
+        sum |> should equal 55 // task-dummies started at 1
+    }
+
+    [<Fact>]
+    let ``TaskSeq-map maps in correct order`` () = task {
+        let! sq =
+            createAsyncEnum 10
+            |> TaskSeq.map (fun item -> char (item + 64))
+            |> TaskSeq.toSeqCachedAsync
+
+        sq
+        |> Seq.map string
+        |> String.concat ""
+        |> should equal "ABCDEFGHIJ"
+    }
+
+    [<Fact>]
+    let ``TaskSeq-mapAsync maps in correct order`` () = task {
+        let! sq =
+            createAsyncEnum 10
+            |> TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
+            |> TaskSeq.toSeqCachedAsync
+
+        sq
+        |> Seq.map string
+        |> String.concat ""
+        |> should equal "ABCDEFGHIJ"
+    }
+
+    [<Fact>]
+    let ``TaskSeq-collect operates in correct order`` () = task {
+        let! sq =
+            createAsyncEnum 10
+            |> TaskSeq.collect (fun item -> taskSeq {
+                yield char (item + 64)
+                yield char (item + 65)
+            })
+            |> TaskSeq.toSeqCachedAsync
+
+        sq
+        |> Seq.map string
+        |> String.concat ""
+        |> should equal "ABBCCDDEEFFGGHHIIJJK"
+    }
+
+    [<Fact>]
+    let ``TaskSeq-collectSeq operates in correct order`` () = task {
+        let! sq =
+            createAsyncEnum 10
+            |> TaskSeq.collectSeq (fun item -> seq {
+                yield char (item + 64)
+                yield char (item + 65)
+            })
+            |> TaskSeq.toSeqCachedAsync
+
+        sq
+        |> Seq.map string
+        |> String.concat ""
+        |> should equal "ABBCCDDEEFFGGHHIIJJK"
+    }
+
+    [<Fact>]
+    let ``TaskSeq-collect with empty task sequences`` () = task {
+        let! sq =
+            createAsyncEnum 10
+            |> TaskSeq.collect (fun _ -> TaskSeq.ofSeq Seq.empty)
+            |> TaskSeq.toSeqCachedAsync
+
+        Seq.isEmpty sq |> should be True
+    }
+
+    [<Fact>]
+    let ``TaskSeq-collectSeq with empty sequences`` () = task {
+        let! sq =
+            createAsyncEnum 10
+            |> TaskSeq.collectSeq (fun _ -> Seq.empty<int>)
+            |> TaskSeq.toSeqCachedAsync
+
+        Seq.isEmpty sq |> should be True
+    }
+
+    [<Fact>]
+    let ``TaskSeq-empty is empty`` () = task {
+        let! sq = TaskSeq.empty<string> |> TaskSeq.toSeqCachedAsync
+        Seq.isEmpty sq |> should be True
+    }
+
+
+module ``PoC's for seq of tasks`` =
+
+
+    [<Fact>]
+    let ``Good: Show joining tasks with continuation is good`` () = task {
+        // acts like a fold
+        let! results = createAndJoinMultipleTasks 10 joinWithContinuation
+        results |> should equal 10
+    }
+
+    [<Fact>]
+    let ``Good: Show that joining tasks with 'bind' in task CE is good`` () = task {
+        let! tasks = createAndJoinMultipleTasks 10 joinIdentityDelayed
+
+        let tasks = tasks |> Array.ofList
+        let len = Array.length tasks
+        let results = Array.zeroCreate len
+
+        for i in 0 .. len - 1 do
+            // this uses Task.bind under the hood, which ensures order-of-execution and wait-for-previous
+            let! item = tasks[i]() // only now are we delay-executing the task in the array
+            results[i] <- item
+
+        results |> should equal <| Array.init len ((+) 1)
+    }
+
+    [<Fact>]
+    let ``Good: Show that joining tasks with 'taskSeq' is good`` () = task {
+        let! tasks = createAndJoinMultipleTasks 10 joinIdentityDelayed
+
+        let asAsyncSeq = taskSeq {
+            for task in tasks do
+                // cannot use `yield!` here, as `taskSeq` expects it to return a seq
+                let! x = task ()
+                yield x
+        }
+
+        let! results = asAsyncSeq |> TaskSeq.toArrayAsync
+
+        results |> should equal
+        <| Array.init (Array.length results) ((+) 1)
+    }
+
+    [<Fact>]
+    let ``Bad: Show that joining tasks with 'traverseTaskResult' can be bad`` () = task {
+        let! taskList = createAndJoinMultipleTasks 10 joinIdentityHotStarted
+
+        // since tasks are hot-started, by this time they are already *all* running
+        let! results =
+            taskList
+            |> List.map (Task.map Result<int, string>.Ok)
+            |> List.traverseTaskResultA id
+
+        match results with
+        | Ok results ->
+            results |> should not'
+            <| equal (List.init (List.length results) ((+) 1))
+        | Error err -> failwith $"Impossible: {err}"
+    }
+
+    [<Fact>]
+    let ``Bad: Show that joining tasks as a list of tasks can be bad`` () = task {
+        let! taskList = createAndJoinMultipleTasks 10 joinIdentityHotStarted
+
+        // since tasks are hot-started, by this time they are already *all* running
+        let tasks = taskList |> Array.ofList
+        let results = Array.zeroCreate 10
+
+        for i in 0..9 do
+            let! item = tasks[i]
+            results[i] <- item
+
+        results |> should not'
+        <| equal (Array.init (Array.length results) ((+) 1))
+    }

--- a/src/FSharpy.TaskSeq.sln
+++ b/src/FSharpy.TaskSeq.sln
@@ -3,7 +3,20 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.3.32811.315
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpy.TaskSeq", "FSharpy.TaskSeq\FSharpy.TaskSeq.fsproj", "{9A723760-A7AB-4C8D-9A6E-F0A38341827C}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharpy.TaskSeq", "FSharpy.TaskSeq\FSharpy.TaskSeq.fsproj", "{9A723760-A7AB-4C8D-9A6E-F0A38341827C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B252135E-C676-4542-8B72-412DF1B9487C}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		..\.github\workflows\build.yaml = ..\.github\workflows\build.yaml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{E55512EE-8DE2-4B44-9A4A-CF779734160B}"
+	ProjectSection(SolutionItems) = preProject
+		..\.github\workflows\build.yaml = ..\.github\workflows\build.yaml
+	EndProjectSection
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpy.TaskSeq.Test", "FSharpy.TaskSeq.Test\FSharpy.TaskSeq.Test.fsproj", "{06CA2C7E-04DA-4A85-BB8E-4D94BD67AEB3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,9 +28,16 @@ Global
 		{9A723760-A7AB-4C8D-9A6E-F0A38341827C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9A723760-A7AB-4C8D-9A6E-F0A38341827C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9A723760-A7AB-4C8D-9A6E-F0A38341827C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06CA2C7E-04DA-4A85-BB8E-4D94BD67AEB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06CA2C7E-04DA-4A85-BB8E-4D94BD67AEB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06CA2C7E-04DA-4A85-BB8E-4D94BD67AEB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06CA2C7E-04DA-4A85-BB8E-4D94BD67AEB3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E55512EE-8DE2-4B44-9A4A-CF779734160B} = {B252135E-C676-4542-8B72-412DF1B9487C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2AE57787-A847-4460-A627-1EB1D224FBC3}

--- a/src/FSharpy.TaskSeq/FSharpy.TaskSeq.fsproj
+++ b/src/FSharpy.TaskSeq/FSharpy.TaskSeq.fsproj
@@ -6,7 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Utils.fs" />
     <Compile Include="TaskSeqBuilder.fs" />
+    <Compile Include="TaskSeqInternal.fs" />
+    <Compile Include="TaskSeq.fs" />
   </ItemGroup>
 
 </Project>

--- a/src/FSharpy.TaskSeq/TaskSeq.fs
+++ b/src/FSharpy.TaskSeq/TaskSeq.fs
@@ -1,11 +1,12 @@
-﻿namespace FSharpy.TaskSeq
+namespace FSharpy
 
 open System.Collections.Generic
 open System.Threading
 open System.Threading.Tasks
 
 module TaskSeq =
-    open TaskSeq
+    open FSharpy.TaskSeqBuilders
+    module Internal = FSharpy.TaskSeqInternal
 
     /// Returns taskSeq as an array. This function is blocking until the sequence is exhausted.
     let toList (t: taskSeq<'T>) = [

--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -1,4 +1,6 @@
-﻿namespace FSharpy.TaskSeq
+namespace FSharpy.TaskSeqBuilders
+
+#nowarn "57" // note: this is *not* an experimental feature, but they forgot to switch off the flag
 
 open System
 open System.Collections.Generic
@@ -10,7 +12,6 @@ open System.Threading.Tasks.Sources
 open FSharp.Core.CompilerServices
 open FSharp.Core.CompilerServices.StateMachineHelpers
 
-#nowarn "57" // note: this is *not* an experimental feature, but they forgot to switch off the flag
 
 [<AutoOpen>]
 module Internal = // cannot be marked with 'internal' scope
@@ -538,8 +539,3 @@ type TaskSeqBuilder() =
                 // For tailcalls we return 'false' and re-run from the entry (trampoline)
                 false
             | _ -> b.YieldFrom(other).Invoke(&sm))
-
-[<AutoOpen>]
-module TaskSeqBuilder =
-    /// A TaskSeq workflow for IAsyncEnumerable<'T> types.
-    let taskSeq = TaskSeqBuilder()

--- a/src/FSharpy.TaskSeq/TaskSeqInternal.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqInternal.fs
@@ -1,93 +1,98 @@
-﻿namespace FSharpy.TaskSeq
+namespace FSharpy
 
 open System.Collections.Generic
 open System.Threading
 open System.Threading.Tasks
+open FSharpy.TaskSeqBuilders
 
-module TaskSeq =
-    module internal Internal =
-        let iteriAsync action (taskSeq: taskSeq<_>) = task {
-            let e = taskSeq.GetAsyncEnumerator(CancellationToken())
-            let mutable go = true
-            let mutable i = 0
+[<AutoOpen>]
+module ExtraTaskSeqOperators =
+    /// A TaskSeq workflow for IAsyncEnumerable<'T> types.
+    let taskSeq = TaskSeqBuilder()
+
+module internal TaskSeqInternal =
+    let iteriAsync action (taskSeq: taskSeq<_>) = task {
+        let e = taskSeq.GetAsyncEnumerator(CancellationToken())
+        let mutable go = true
+        let mutable i = 0
+        let! step = e.MoveNextAsync()
+        go <- step
+
+        while go do
+            action i e.Current
+            let! step = e.MoveNextAsync()
+            i <- i + 1
+            go <- step
+    }
+
+    let fold (action: 'State -> 'T -> 'State) initial (taskSeq: taskSeq<_>) = task {
+        let e = taskSeq.GetAsyncEnumerator(CancellationToken())
+        let mutable go = true
+        let mutable result = initial
+        let! step = e.MoveNextAsync()
+        go <- step
+
+        while go do
+            result <- action result e.Current
             let! step = e.MoveNextAsync()
             go <- step
 
-            while go do
-                action i e.Current
-                let! step = e.MoveNextAsync()
-                i <- i + 1
-                go <- step
-        }
+        return result
+    }
 
-        let fold (action: 'State -> 'T -> 'State) initial (taskSeq: taskSeq<_>) = task {
-            let e = taskSeq.GetAsyncEnumerator(CancellationToken())
-            let mutable go = true
-            let mutable result = initial
-            let! step = e.MoveNextAsync()
-            go <- step
+    let toResizeArrayAsync taskSeq = task {
+        let res = ResizeArray()
+        do! taskSeq |> iteriAsync (fun _ item -> res.Add item)
+        return res
+    }
 
-            while go do
-                result <- action result e.Current
-                let! step = e.MoveNextAsync()
-                go <- step
+    let mapi mapper (taskSequence: taskSeq<_>) = taskSeq {
+        let mutable i = 0
 
-            return result
-        }
+        for c in taskSequence do
+            yield mapper i c
+            i <- i + 1
+    }
 
-        let toResizeArrayAsync taskSeq = task {
-            let res = ResizeArray()
-            do! taskSeq |> iteriAsync (fun _ item -> res.Add item)
-            return res
-        }
+    let mapiAsync (mapper: _ -> _ -> Task<'T>) (taskSequence: taskSeq<_>) = taskSeq {
+        let mutable i = 0
 
-        let mapi mapper (taskSequence: taskSeq<_>) = taskSeq {
-            let mutable i = 0
+        for c in taskSequence do
+            let! x = mapper i c
+            yield x
+            i <- i + 1
+    }
 
-            for c in taskSequence do
-                yield mapper i c
-                i <- i + 1
-        }
+    let zip (taskSequence1: taskSeq<_>) (taskSequence2: taskSeq<_>) = taskSeq {
+        let e1 = taskSequence1.GetAsyncEnumerator(CancellationToken())
+        let e2 = taskSequence2.GetAsyncEnumerator(CancellationToken())
+        let mutable go = true
+        let! step1 = e1.MoveNextAsync()
+        let! step2 = e1.MoveNextAsync()
+        go <- step1 && step2
 
-        let mapiAsync (mapper: _ -> _ -> Task<'T>) (taskSequence: taskSeq<_>) = taskSeq {
-            let mutable i = 0
-
-            for c in taskSequence do
-                let! x = mapper i c
-                yield x
-                i <- i + 1
-        }
-
-        let zip (taskSequence1: taskSeq<_>) (taskSequence2: taskSeq<_>) = taskSeq {
-            let e1 = taskSequence1.GetAsyncEnumerator(CancellationToken())
-            let e2 = taskSequence2.GetAsyncEnumerator(CancellationToken())
-            let mutable go = true
+        while go do
+            yield e1.Current, e2.Current
             let! step1 = e1.MoveNextAsync()
             let! step2 = e1.MoveNextAsync()
             go <- step1 && step2
 
-            while go do
-                yield e1.Current, e2.Current
-                let! step1 = e1.MoveNextAsync()
-                let! step2 = e1.MoveNextAsync()
-                go <- step1 && step2
+        if step1 then
+            invalidArg "taskSequence1" "The task sequences had different lengths."
 
-            if step1 then
-                invalidArg "taskSequence1" "The task sequences had different lengths."
+        if step2 then
+            invalidArg "taskSequence2" "The task sequences had different lengths."
+    }
 
-            if step2 then
-                invalidArg "taskSequence2" "The task sequences had different lengths."
-        }
+    let collect (binder: _ -> #IAsyncEnumerable<_>) (taskSequence: taskSeq<_>) = taskSeq {
+        for c in taskSequence do
+            yield! binder c :> IAsyncEnumerable<_>
+    }
 
-        let collect (binder: _ -> #IAsyncEnumerable<_>) (taskSequence: taskSeq<_>) = taskSeq {
-            for c in taskSequence do
-                yield! binder c :> IAsyncEnumerable<_>
-        }
-
-        let collectSeq (binder: _ -> #seq<_>) (taskSequence: taskSeq<_>) = taskSeq {
-            for c in taskSequence do
-                yield! binder c :> seq<_>
-        }
+    let collectSeq (binder: _ -> #seq<_>) (taskSequence: taskSeq<_>) = taskSeq {
+        for c in taskSequence do
+            yield! binder c :> seq<_>
+    }
 
     /// Returns taskSeq as an array. This function is blocking until the sequence is exhausted.
     let toListResult (t: taskSeq<'T>) = [

--- a/src/FSharpy.TaskSeq/Utils.fs
+++ b/src/FSharpy.TaskSeq/Utils.fs
@@ -1,4 +1,4 @@
-﻿namespace FSharpy.TaskSeq
+namespace FSharpy
 
 open System.Threading.Tasks
 
@@ -31,8 +31,7 @@ module Task =
         }
 
     /// Bind a Task<'T>
-    let inline bind binder (task: Task<'T>) : Task<'U> =
-        TaskBuilder.task { return! binder task }
+    let inline bind binder (task: Task<'T>) : Task<'U> = TaskBuilder.task { return! binder task }
 
 module Async =
     /// Convert an Task<'T> into an Async<'T>
@@ -45,11 +44,10 @@ module Async =
     let inline toTask (async: Async<'T>) = task { return! async }
 
     /// Convert an Async<'T> into an Async<unit>, ignoring the result
-    let inline ignore (async': Async<'T>) =
-        async {
-            let! _ = async'
-            return ()
-        }
+    let inline ignore (async': Async<'T>) = async {
+        let! _ = async'
+        return ()
+    }
 
     /// Map an Async<'T>
     let inline map mapper (async: Async<'T>) : Async<'U> =
@@ -59,5 +57,4 @@ module Async =
         }
 
     /// Bind an Async<'T>
-    let inline bind binder (task: Async<'T>) : Async<'U> =
-        ExtraTopLevelOperators.async { return! binder task }
+    let inline bind binder (task: Async<'T>) : Async<'U> = ExtraTopLevelOperators.async { return! binder task }


### PR DESCRIPTION
This PR reorganizes the way the modules and namespaces are named. At this moment I'm not yet sure if `open FSharpy` or `open FSharpy.TaskSeq` is preferred.

I tend towards the former, as `TaskSeq` is already the name of the module and I'm not a fan of nesting a module under a namespace with exactly the same name-segment.