### PR TITLE
Replace Task.Delay, which has only 15ms or so resolution, with an alternative, high-performance timer

### DIFF
--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.fs
@@ -1,10 +1,12 @@
-module FSharpy.TaskSeq.Tests.``taskSeq Computation Expression``
+﻿module FSharpy.TaskSeq.Tests.``taskSeq Computation Expression``
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
 open FSharpy
+open System.Threading.Tasks
+open System.Diagnostics
 
 
 [<Fact>]
@@ -20,6 +22,94 @@ let ``CE taskSeq with several yield!`` () = task {
 
     data
     |> should equal (List.concat [ [ 1..10 ]; [ 1..5 ]; [ 1..10 ]; [ 1..5 ] ])
+}
+
+[<Fact>]
+let ``CE taskSeq with nested yield!`` () = task {
+    let control = seq {
+        yield! [ 1..10 ]
+
+        for i in 0..9 do
+            yield! [ 1..2 ]
+
+            for i in 0..2 do
+                yield! seq { yield 42 }
+
+                for i in 100..102 do
+                    yield! seq { yield! seq { yield i } }
+    }
+
+    let tskSeq = taskSeq {
+        yield! createDummyTaskSeq 10
+
+        for i in 0..9 do
+            yield! createDummyTaskSeq 2
+
+            for i in 0..2 do
+                yield! taskSeq { yield 42 }
+
+                for i in 100..102 do
+                    yield! taskSeq { yield! taskSeq { yield i } }
+    }
+
+    let! data = tskSeq |> TaskSeq.toListAsync
+
+    data |> should equal (List.ofSeq control)
+    data |> should haveLength 150
+}
+
+[<Fact>]
+let ``CE taskSeq with nested deeply yield! perf test`` () = task {
+    let control = seq {
+        yield! [ 1..10 ]
+
+        // original:
+        // yield! Seq.concat <| Seq.init 2145 (fun _ -> [ 1; 2 ])
+        yield! Seq.concat <| Seq.init 120 (fun _ -> [ 1; 2 ])
+    }
+
+    let createTasks = createDummyTaskSeqWith 1L<µs> 10L<µs>
+    // FIXME: it appears that deeply nesting adds to performance degradation, need to benchmark/profile this
+    // probably cause: since this is *fast* with DirectTask, the reason is likely the way the Task.Delay causes
+    // *many* subtasks to be delayed, resulting in exponential delay. Reason: max accuracy of Delay is about 15ms (!)
+    let tskSeq = taskSeq {
+        yield! createTasks 10
+
+        // nestings amount to 2145 sequences of [1;2]
+        for i in 0..2 do
+            yield! createTasks 2
+
+            for i in 0..2 do
+                yield! createTasks 2
+
+                for i in 0..2 do
+                    yield! createTasks 2
+
+                    for i in 0..2 do
+                        yield! createTasks 2
+                        // stopping here, at a total 250 nested taskSeq
+                        // add the below to get to 4300
+
+                        //for i in 0..2 do
+                        //    yield! createTasks 2
+
+                        //    for i in 0..2 do
+                        //        yield! createTasks 2
+
+                        //for i in 0..2 do
+                        //    yield! createTasks 2
+
+                        //    for i in 0..2 do
+                        //        yield! createTasks 2
+
+                        //        for i in 0..2 do
+                        //            yield! createTasks 2
+                        yield! TaskSeq.empty
+    }
+
+    let! data = tskSeq |> TaskSeq.toListAsync
+    data |> List.length |> should equal 250
+    data |> should equal (List.ofSeq control)
 }
 
 [<Fact>]
@@ -56,118 +146,60 @@ let ``CE taskSeq with mixing yield! and yield`` () = task {
 }
 
 [<Fact>]
-let ``CE taskSeq with nested deeply yield! perf test`` () = task {
-    let control = seq {
-        yield! [ 1..10 ]
-
-        // original:
-        // yield! Seq.concat <| Seq.init 4251 (fun _ -> [ 1; 2 ])
-        yield! Seq.concat <| Seq.init 120 (fun _ -> [ 1; 2 ])
-    }
-
-    //let createTasks = createDummyTaskSeqWith 1L<�s> 10L<�s>
-    // FIXME: it appears that deeply nesting adds to performance degradation, need to benchmark/profile this
-    // probably cause: since this is *fast* with DirectTask, the reason is likely the way the Task.Delay causes
-    // *many* subtasks to be delayed, resulting in exponential delay. Reason: max accuracy of Delay is about 15ms (!)
-    let tskSeq = taskSeq {
-        yield! createDummyTaskSeq 10
-
-        // nestings amount to 8512 sequences of [1;2]
-        for i in 0..2 do
-            yield! createDummyTaskSeq 2
-
-            for i in 0..2 do
-                yield! createDummyTaskSeq 2
-
-                for i in 0..2 do
-                    yield! createDummyTaskSeq 2
-
-                    for i in 0..2 do
-                        yield! createDummyTaskSeq 2
-                        // stopping here, at a total 250 nested taskSeq
-                        // add the below to get to 4300
-
-                        //for i in 0..2 do
-                        //    yield! createDummyTaskSeq 2
-
-                        //    for i in 0..2 do
-                        //        yield! createDummyTaskSeq 2
-
-                        //for i in 0..2 do
-                        //    yield! createDummyTaskSeq 2
-
-                        //    for i in 0..2 do
-                        //        yield! createDummyTaskSeq 2
-
-                        //        for i in 0..2 do
-                        //            yield! createDummyTaskSeq 2
-                        yield! TaskSeq.empty
-    }
-
+let ``CE taskSeq: 1000 TaskDelay-delayed tasks using yield!`` () = task {
+    // Smoke performance test
+    // Runs in slightly over half a second (average of spin-wait, plus small overhead)
+    // should generally be about as fast as `task`, see below for equivalent test.
+    let tskSeq = taskSeq { yield! createDummyTaskSeqWith 50L<µs> 1000L<µs> 1000 }
     let! data = tskSeq |> TaskSeq.toListAsync
-    data |> List.length |> should equal 250 // 8512
-    data |> should equal (List.ofSeq control)
+    data |> should equal [ 1..1000 ]
 }
 
 [<Fact>]
-let ``CE taskSeq: 500 TaskDelay-delayed tasks using yield!`` () = task {
-    // runs in 10-15s because of Task.Delay between 10-30ms
+let ``CE taskSeq: 1000 sync-running tasks using yield!`` () = task {
+    // Smoke performance test
+    // Runs in a few 10's of ms, because of absense of Task.Delay
     // should generally be about as fast as `task`, see below
-    let tskSeq = taskSeq { yield! createDummyTaskSeq 500 }
-
+    let tskSeq = taskSeq { yield! createDummyDirectTaskSeq 1000 }
     let! data = tskSeq |> TaskSeq.toListAsync
-
-    data |> should equal [ 1..500 ]
-}
-
-[<Fact>]
-let ``CE taskSeq: 500 sync-running tasks using yield!`` () = task {
-    // runs in a few 10's of ms, because of absense of Task.Delay
-    // should generally be about as fast as `task`, see below
-    let tskSeq = taskSeq { yield! createDummyDirectTaskSeq 500 }
-
-    let! data = tskSeq |> TaskSeq.toListAsync
-
-    data |> should equal [ 1..500 ]
+    data |> should equal [ 1..1000 ]
 }
 
 [<Fact>]
 let ``CE taskSeq: 5000 sync-running tasks using yield!`` () = task {
-    // runs in a few 100's of ms, because of absense of Task.Delay
-    // should generally be about as fast as `task`, see below
+    // Smoke performance test
+    // Compare with task-ce test below. Uses a no-delay hot-started sequence of tasks.
     let tskSeq = taskSeq { yield! createDummyDirectTaskSeq 5000 }
-
     let! data = tskSeq |> TaskSeq.toListAsync
-
     data |> should equal [ 1..5000 ]
 }
 
 [<Fact>]
-let ``CE task: 500 TaskDelay-delayed tasks using for-loop`` () = task {
-    // runs in 10-15s because of Task.Delay between 10-30ms
+let ``CE task: 1000 TaskDelay-delayed tasks using for-loop`` () = task {
+    // Uses SpinWait for effective task-delaying
     // for smoke-test comparison with taskSeq
-    let tasks = DummyTaskFactory().CreateDelayedTasks 500
+    let tasks = DummyTaskFactory(50L<µs>, 1000L<µs>).CreateDelayedTasks 1000
     let mutable i = 0
 
     for t in tasks do
         i <- i + 1
         do! t () |> Task.ignore
 
-    i |> should equal 500
+    i |> should equal 1000
 }
 
 [<Fact>]
-let ``CE task: 500 list of sync-running tasks using for-loop`` () = task {
+let ``CE task: 1000 list of sync-running tasks using for-loop`` () = task {
     // runs in a few 10's of ms, because of absense of Task.Delay
     // for smoke-test comparison with taskSeq
-    let tasks = DummyTaskFactory().CreateDirectTasks 500
+    let tasks = DummyTaskFactory().CreateDirectTasks 1000
     let mutable i = 0
 
     for t in tasks do
         i <- i + 1
         do! t () |> Task.ignore
 
-    i |> should equal 500
+    i |> should equal 1000
 }
 
 [<Fact>]


### PR DESCRIPTION
Fixes #15.

It appears that the issue in #15 is caused by how `Task.Delay` is highly imprecise (with, depending on system, a 15ms resolution). Replacing it with what seems to be a possible high-resolution alternative (see this IoT helper code: https://github.com/dotnet/iot/pull/235), which uses `SpinWait` and `SpinOnce` to delay the task, the "performance" issues disappeared as snow in the sun.

The expected timings of these smoke-tests should be roughly the amount of tasks divided by the average random delay configured for each task (this is a test feature only!). 

It brings the offending tests from 15s runtime or more down to 600ms, with double the amount of test-tasks.

There are still some questions, mainly _why does the `spinwait.SpinOnce`_ cause a 15ms delay per task on average?

TLDR: we now have a microsecond task-delay timer 😆!