### PR TITLE
Add TaskSeq.fold and TaskSeq.foldAsync functions

### DIFF
--- a/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
+++ b/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="TaskSeq.Iter.Tests.fs" />
     <Compile Include="TaskSeq.Map.Tests.fs" />
     <Compile Include="TaskSeq.Collect.Tests.fs" />
+    <Compile Include="TaskSeq.Fold.Tests.fs" />
     <Compile Include="TaskSeq.Tests.Utility.fs" />
     <Compile Include="TaskSeq.Tests.fs" />
     <Compile Include="TaskSeq.PocTests.fs" />

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
@@ -1,0 +1,49 @@
+module FSharpy.TaskSeq.Tests.Fold
+
+open System.Text
+open Xunit
+open FsUnit.Xunit
+open FsToolkit.ErrorHandling
+
+open FSharpy
+
+
+[<Fact>]
+let ``TaskSeq-fold folds with every item`` () = task {
+    let! alphabet =
+        createDummyTaskSeqWith 50L<µs> 1000L<µs> 26
+        |> TaskSeq.fold (fun (state: StringBuilder) item -> state.Append(char item + '@')) (StringBuilder())
+
+    alphabet.ToString()
+    |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+}
+
+[<Fact>]
+let ``TaskSeq-foldAsync folds with every item`` () = task {
+    let! alphabet =
+        createDummyTaskSeqWith 50L<µs> 1000L<µs> 26
+        |> TaskSeq.foldAsync
+            (fun (state: StringBuilder) item -> task { return state.Append(char item + '@') })
+            (StringBuilder())
+
+    alphabet.ToString()
+    |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+}
+
+[<Fact>]
+let ``TaskSeq-fold takes state on empty IAsyncEnumberable`` () = task {
+    let! empty =
+        TaskSeq.empty
+        |> TaskSeq.fold (fun _ item -> char (item + 64)) '_'
+
+    empty |> should equal '_'
+}
+
+[<Fact>]
+let ``TaskSeq-foldAsync takes state on empty IAsyncEnumerable`` () = task {
+    let! alphabet =
+        TaskSeq.empty
+        |> TaskSeq.foldAsync (fun _ item -> task { return char (item + 64) }) '_'
+
+    alphabet |> should equal '_'
+}

--- a/src/FSharpy.TaskSeq.Test/TestUtils.fs
+++ b/src/FSharpy.TaskSeq.Test/TestUtils.fs
@@ -162,4 +162,4 @@ module TestUtils =
         }
 
     /// Create a bunch of dummy tasks, each lasting between 10-30ms with spin-wait delays.
-    let createDummyTaskSeq = createDummyTaskSeqWith 10_0000L<µs> 30_0000L<µs>
+    let createDummyTaskSeq = createDummyTaskSeqWith 10_000L<µs> 30_000L<µs>

--- a/src/FSharpy.TaskSeq/TaskSeq.fs
+++ b/src/FSharpy.TaskSeq/TaskSeq.fs
@@ -197,3 +197,9 @@ module TaskSeq =
     /// Zips two task sequences, returning a taskSeq of the tuples of each sequence, in order. May raise ArgumentException
     /// if the sequences are or unequal length.
     let zip taskSeq1 taskSeq2 = Internal.zip taskSeq1 taskSeq2
+
+    /// Applies a function to each element of the task sequence, threading an accumulator argument through the computation.
+    let fold folder state taskSeq = Internal.fold (FolderAction folder) state taskSeq
+
+    /// Applies an async function to each element of the task sequence, threading an accumulator argument through the computation.
+    let foldAsync folder state taskSeq = Internal.fold (AsyncFolderAction folder) state taskSeq


### PR DESCRIPTION
This adds the following two functions and a few tests, which should greatly simplify accumulating a value throughout an `IAsyncEnumerable`.

I should probably emphasize already that I'm not planning to have a `TaskSeq.foldBack` and `TaskSeq.foldBackAsync`, as it would require walking the full async sequence, caching it, and then reverse-accumulating, which defeats the purpose of a delay-executed asynchronous sequence. If you have that use-case, you can use `TaskSeq.toArrayAsync >> Task.map (Array.foldBack yourFolderFunction yourState)`.

```f#
module TaskSeq =
    /// Applies a function to each element of the task sequence, threading an accumulator argument through the computation.
    val fold: folder: ('State -> 'T -> 'State) -> state: 'State -> taskSeq: IAsyncEnumerable<'T> -> Task<'State>

    /// Applies an async function to each element of the task sequence, threading an accumulator argument through the computation.
    val foldAsync: folder: ('State -> 'T -> #Task<'State>) -> state: 'State -> taskSeq: IAsyncEnumerable<'T> -> Task<'State>

```