### PR TITLE
Investigate deadlock, hanging of tests in CI, whether it is CI, F# tasks, TaskSeq CE or XUnit, see also #25

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-dotnet@v3
       # build it, test it, pack it
       - name: Run dotnet test - release
-        run: dotnet test -c Release --blame-hang-timeout 15000ms --logger "trx;LogFileName=test-results-release.trx" --logger "console;verbosity=detailed" .\src\FSharpy.TaskSeq.Test\FSharpy.TaskSeq.Test.fsproj
+        run: dotnet test -c Release --blame-hang-timeout 60000ms --logger "trx;LogFileName=test-results-release.trx" --logger "console;verbosity=detailed" .\src\FSharpy.TaskSeq.Test\FSharpy.TaskSeq.Test.fsproj
       - name: Publish test results - release
         uses: dorny/test-reporter@v1
         if: always()
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-dotnet@v3
       # build it, test it, pack it
       - name: Run dotnet test - debug
-        run: dotnet test -c Debug --blame-hang-timeout 15000ms --logger "trx;LogFileName=test-results-debug.trx" --logger "console;verbosity=detailed" .\src\FSharpy.TaskSeq.Test\FSharpy.TaskSeq.Test.fsproj
+        run: dotnet test -c Debug --blame-hang-timeout 60000ms --logger "trx;LogFileName=test-results-debug.trx" --logger "console;verbosity=detailed" .\src\FSharpy.TaskSeq.Test\FSharpy.TaskSeq.Test.fsproj
       - name: Publish test results - debug
         uses: dorny/test-reporter@v1
         if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-dotnet@v3
       # build it, test it, pack it
       - name: Run dotnet test - release
-        run: dotnet test -c Release --blame-hang-timeout 15000ms --logger "trx;LogFileName=test-results-release.trx" --logger "console;verbosity=detailed" .\src\FSharpy.TaskSeq.Test\FSharpy.TaskSeq.Test.fsproj
+        run: dotnet test -c Release --blame-hang-timeout 60000ms --logger "trx;LogFileName=test-results-release.trx" --logger "console;verbosity=detailed" .\src\FSharpy.TaskSeq.Test\FSharpy.TaskSeq.Test.fsproj
       - name: Publish test results - release
         uses: dorny/test-reporter@v1
         if: always()
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-dotnet@v3
       # build it, test it, pack it
       - name: Run dotnet test - debug
-        run: dotnet test -c Debug --blame-hang-timeout 15000ms --logger "trx;LogFileName=test-results-debug.trx" --logger "console;verbosity=detailed" .\src\FSharpy.TaskSeq.Test\FSharpy.TaskSeq.Test.fsproj
+        run: dotnet test -c Debug --blame-hang-timeout 60000ms --logger "trx;LogFileName=test-results-debug.trx" --logger "console;verbosity=detailed" .\src\FSharpy.TaskSeq.Test\FSharpy.TaskSeq.Test.fsproj
       - name: Publish test results - debug
         uses: dorny/test-reporter@v1
         if: always()
@@ -50,4 +50,3 @@ jobs:
           # this path glob pattern requires forward slashes!
           path: ./src/FSharpy.TaskSeq.Test/TestResults/test-results-debug.trx
           reporter: dotnet-trx
-          

--- a/src/FSharpy.TaskSeq.Test/AssemblyInfo.fs
+++ b/src/FSharpy.TaskSeq.Test/AssemblyInfo.fs
@@ -2,7 +2,7 @@ namespace FSharpy.Tests
 
 open System.Runtime.CompilerServices
 
-[<assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)>]
+[<assembly: Xunit.CollectionBehavior(DisableTestParallelization = false)>]
 [<assembly: Xunit.TestCaseOrderer("FSharpy.Tests.AlphabeticalOrderer", "FSharpy.TaskSeq.Test")>]
 
 do ()

--- a/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
+++ b/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Nunit.Extensions.fs" />
     <Compile Include="TestUtils.fs" />
+    <Compile Include="TaskSeq.AllTests.fs" />
     <Compile Include="TaskSeq.Choose.Tests.fs" />
     <Compile Include="TaskSeq.Collect.Tests.fs" />
     <Compile Include="TaskSeq.Filter.Tests.fs" />

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.AllTests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.AllTests.fs
@@ -1,0 +1,153 @@
+namespace FSharpy.Tests
+
+open System
+open System.Threading.Tasks
+open System.Reflection
+
+open Xunit
+open FsUnit.Xunit
+open FsToolkit.ErrorHandling
+
+open FSharpy
+open Xunit.Abstractions
+
+
+type AllTests(output: ITestOutputHelper) =
+    let createParallelRunner () =
+        let myAsm = Assembly.GetExecutingAssembly()
+
+        let allMethods = [
+            for ty in myAsm.DefinedTypes do
+                for mem in ty.DeclaredMembers do
+                    match mem.MemberType with
+                    | MemberTypes.Method ->
+                        if mem.Name.StartsWith("TaskSeq") || mem.Name.StartsWith("CE") then
+                            yield ty, mem :?> MethodInfo
+                    | _ -> ()
+        ]
+
+        let all = seq {
+            for (ty, method) in allMethods do
+                let ctor = ty.GetConstructor [| typeof<ITestOutputHelper> |]
+
+                if isNull ctor then
+                    failwith "Constructor for test not found"
+
+                let testObj = ctor.Invoke([| output |])
+
+                if method.ReturnType.Name.Contains "Task" then
+                    //task {
+                    //    let! x = Async.StartChildAsTask (Async.ofTask (method.Invoke(testObj, null) :?> Task<unit>))
+                    //    return! x
+                    //}
+                    async {
+                        return!
+                            method.Invoke(testObj, null) :?> Task<unit>
+                            |> Async.AwaitTask
+                    }
+                else
+                    async { return method.Invoke(testObj, null) |> ignore }
+        }
+
+        all |> Async.Parallel |> Async.map ignore
+
+    let multiply f x =
+        seq {
+            for i in [ 0..x ] do
+                yield f ()
+        }
+        |> Async.Parallel
+        |> Async.map ignore
+
+    [<Fact>]
+    let ``Run all tests 1 times in parallel`` () = task { do! multiply createParallelRunner 1 }
+
+    [<Theory>]
+    [<InlineData 1; InlineData 2; InlineData 3; InlineData 4; InlineData 5; InlineData 6; InlineData 7; InlineData 8>]
+    let ``Run all tests X times in parallel`` i = task { do! multiply createParallelRunner i }
+
+    [<Theory>]
+    [<InlineData 1; InlineData 2; InlineData 3; InlineData 4; InlineData 5; InlineData 6; InlineData 7; InlineData 8>]
+    let ``Run all tests again X times in parallel`` i = task { do! multiply createParallelRunner i }
+
+    [<Theory>]
+    [<InlineData 1; InlineData 2; InlineData 3; InlineData 4; InlineData 5; InlineData 6; InlineData 7; InlineData 8>]
+    let ``Run all tests and once more, X times in parallel`` i = task { do! multiply createParallelRunner i }
+
+
+//[<Fact>]
+//let ``Run all tests 3 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously
+
+
+//[<Fact>]
+//let ``Run all tests 4 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously
+
+
+//[<Fact>]
+//let ``Run all tests 5 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously
+
+
+//[<Fact>]
+//let ``Run all tests 6 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously
+
+
+//[<Fact>]
+//let ``Run all tests 7 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously
+
+
+//[<Fact>]
+//let ``Run all tests 8 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously
+
+
+//[<Fact>]
+//let ``Run all tests 9 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously
+
+
+//[<Fact>]
+//let ``Run all tests 10 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously
+
+
+//[<Fact>]
+//let ``Run all tests 11 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously
+
+
+//[<Fact>]
+//let ``Run all tests 12 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously
+
+
+//[<Fact>]
+//let ``Run all tests 13 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously
+
+
+//[<Fact>]
+//let ``Run all tests 14 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously
+
+
+//[<Fact>]
+//let ``Run all tests 15 times in parallel`` () =
+//    multiply createParallelRunner 15
+//    |> Async.RunSynchronously

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
@@ -13,7 +13,7 @@ open Xunit.Abstractions
 
 type Choose(output: ITestOutputHelper) =
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``ZHang timeout test`` () =
         logStart output
 
@@ -22,7 +22,7 @@ type Choose(output: ITestOutputHelper) =
             empty |> should be Null
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-choose on an empty sequence`` () =
         logStart output
 
@@ -35,7 +35,7 @@ type Choose(output: ITestOutputHelper) =
             List.isEmpty empty |> should be True
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-chooseAsync on an empty sequence`` () =
         logStart output
 
@@ -48,7 +48,7 @@ type Choose(output: ITestOutputHelper) =
             List.isEmpty empty |> should be True
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-choose can convert and filter`` () =
         logStart output
 
@@ -61,7 +61,7 @@ type Choose(output: ITestOutputHelper) =
             String alphabet |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-chooseAsync can convert and filter`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
@@ -9,14 +9,14 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``ZHang timeout test`` () = task {
     let! empty = Task.Delay 30
 
     empty |> should be Null
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-choose on an empty sequence`` () = task {
     let! empty =
         TaskSeq.empty
@@ -26,7 +26,7 @@ let ``TaskSeq-choose on an empty sequence`` () = task {
     List.isEmpty empty |> should be True
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-chooseAsync on an empty sequence`` () = task {
     let! empty =
         TaskSeq.empty
@@ -36,7 +36,7 @@ let ``TaskSeq-chooseAsync on an empty sequence`` () = task {
     List.isEmpty empty |> should be True
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-choose can convert and filter`` () = task {
     let! alphabet =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -46,7 +46,7 @@ let ``TaskSeq-choose can convert and filter`` () = task {
     String alphabet |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-chooseAsync can convert and filter`` () = task {
     let! alphabet =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Choose
+namespace FSharpy.Tests
 
 open System
 open System.Threading.Tasks
@@ -8,50 +8,68 @@ open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
 open FSharpy
+open Xunit.Abstractions
 
-[<Fact(Timeout = 10_000)>]
-let ``ZHang timeout test`` () = task {
-    let! empty = Task.Delay 30
 
-    empty |> should be Null
-}
+type Choose(output: ITestOutputHelper) =
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-choose on an empty sequence`` () = task {
-    let! empty =
-        TaskSeq.empty
-        |> TaskSeq.choose (fun _ -> Some 42)
-        |> TaskSeq.toListAsync
+    [<Fact(Timeout = 10_000)>]
+    let ``ZHang timeout test`` () =
+        logStart output
 
-    List.isEmpty empty |> should be True
-}
+        task {
+            let! empty = Task.Delay 30
+            empty |> should be Null
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-chooseAsync on an empty sequence`` () = task {
-    let! empty =
-        TaskSeq.empty
-        |> TaskSeq.chooseAsync (fun _ -> task { return Some 42 })
-        |> TaskSeq.toListAsync
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-choose on an empty sequence`` () =
+        logStart output
 
-    List.isEmpty empty |> should be True
-}
+        task {
+            let! empty =
+                TaskSeq.empty
+                |> TaskSeq.choose (fun _ -> Some 42)
+                |> TaskSeq.toListAsync
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-choose can convert and filter`` () = task {
-    let! alphabet =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.choose (fun number -> if number <= 26 then Some(char number + '@') else None)
-        |> TaskSeq.toArrayAsync
+            List.isEmpty empty |> should be True
+        }
 
-    String alphabet |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-chooseAsync on an empty sequence`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-chooseAsync can convert and filter`` () = task {
-    let! alphabet =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.choose (fun number -> if number <= 26 then Some(char number + '@') else None)
-        |> TaskSeq.toArrayAsync
+        task {
+            let! empty =
+                TaskSeq.empty
+                |> TaskSeq.chooseAsync (fun _ -> task { return Some 42 })
+                |> TaskSeq.toListAsync
 
-    String alphabet |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-}
+            List.isEmpty empty |> should be True
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-choose can convert and filter`` () =
+        logStart output
+
+        task {
+            let! alphabet =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.choose (fun number -> if number <= 26 then Some(char number + '@') else None)
+                |> TaskSeq.toArrayAsync
+
+            String alphabet |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-chooseAsync can convert and filter`` () =
+        logStart output
+
+        task {
+            let! alphabet =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.choose (fun number -> if number <= 26 then Some(char number + '@') else None)
+                |> TaskSeq.toArrayAsync
+
+            String alphabet |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
@@ -8,7 +8,7 @@ open FSharpy
 
 type Collect(output) =
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-collect operates in correct order`` () =
         logStart output
 
@@ -27,7 +27,7 @@ type Collect(output) =
             |> should equal "ABBCCDDEEFFGGHHIIJJK"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-collectSeq operates in correct order`` () =
         logStart output
 
@@ -46,7 +46,7 @@ type Collect(output) =
             |> should equal "ABBCCDDEEFFGGHHIIJJK"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-collect with empty task sequences`` () =
         logStart output
 
@@ -59,7 +59,7 @@ type Collect(output) =
             Seq.isEmpty sq |> should be True
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-collectSeq with empty sequences`` () =
         logStart output
 
@@ -72,7 +72,7 @@ type Collect(output) =
             Seq.isEmpty sq |> should be True
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-empty is empty`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
@@ -6,7 +6,7 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-collect operates in correct order`` () = task {
     let! sq =
         createDummyTaskSeq 10
@@ -22,7 +22,7 @@ let ``TaskSeq-collect operates in correct order`` () = task {
     |> should equal "ABBCCDDEEFFGGHHIIJJK"
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-collectSeq operates in correct order`` () = task {
     let! sq =
         createDummyTaskSeq 10
@@ -38,7 +38,7 @@ let ``TaskSeq-collectSeq operates in correct order`` () = task {
     |> should equal "ABBCCDDEEFFGGHHIIJJK"
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-collect with empty task sequences`` () = task {
     let! sq =
         createDummyTaskSeq 10
@@ -48,7 +48,7 @@ let ``TaskSeq-collect with empty task sequences`` () = task {
     Seq.isEmpty sq |> should be True
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-collectSeq with empty sequences`` () = task {
     let! sq =
         createDummyTaskSeq 10
@@ -58,7 +58,7 @@ let ``TaskSeq-collectSeq with empty sequences`` () = task {
     Seq.isEmpty sq |> should be True
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-empty is empty`` () = task {
     let! sq = TaskSeq.empty<string> |> TaskSeq.toSeqCachedAsync
     Seq.isEmpty sq |> should be True

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Collect
+namespace FSharpy.Tests
 
 open Xunit
 open FsUnit.Xunit
@@ -6,60 +6,77 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-collect operates in correct order`` () = task {
-    let! sq =
-        createDummyTaskSeq 10
-        |> TaskSeq.collect (fun item -> taskSeq {
-            yield char (item + 64)
-            yield char (item + 65)
-        })
-        |> TaskSeq.toSeqCachedAsync
+type Collect(output) =
 
-    sq
-    |> Seq.map string
-    |> String.concat ""
-    |> should equal "ABBCCDDEEFFGGHHIIJJK"
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-collect operates in correct order`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-collectSeq operates in correct order`` () = task {
-    let! sq =
-        createDummyTaskSeq 10
-        |> TaskSeq.collectSeq (fun item -> seq {
-            yield char (item + 64)
-            yield char (item + 65)
-        })
-        |> TaskSeq.toSeqCachedAsync
+        task {
+            let! sq =
+                createDummyTaskSeq 10
+                |> TaskSeq.collect (fun item -> taskSeq {
+                    yield char (item + 64)
+                    yield char (item + 65)
+                })
+                |> TaskSeq.toSeqCachedAsync
 
-    sq
-    |> Seq.map string
-    |> String.concat ""
-    |> should equal "ABBCCDDEEFFGGHHIIJJK"
-}
+            sq
+            |> Seq.map string
+            |> String.concat ""
+            |> should equal "ABBCCDDEEFFGGHHIIJJK"
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-collect with empty task sequences`` () = task {
-    let! sq =
-        createDummyTaskSeq 10
-        |> TaskSeq.collect (fun _ -> TaskSeq.ofSeq Seq.empty)
-        |> TaskSeq.toSeqCachedAsync
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-collectSeq operates in correct order`` () =
+        logStart output
 
-    Seq.isEmpty sq |> should be True
-}
+        task {
+            let! sq =
+                createDummyTaskSeq 10
+                |> TaskSeq.collectSeq (fun item -> seq {
+                    yield char (item + 64)
+                    yield char (item + 65)
+                })
+                |> TaskSeq.toSeqCachedAsync
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-collectSeq with empty sequences`` () = task {
-    let! sq =
-        createDummyTaskSeq 10
-        |> TaskSeq.collectSeq (fun _ -> Seq.empty<int>)
-        |> TaskSeq.toSeqCachedAsync
+            sq
+            |> Seq.map string
+            |> String.concat ""
+            |> should equal "ABBCCDDEEFFGGHHIIJJK"
+        }
 
-    Seq.isEmpty sq |> should be True
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-collect with empty task sequences`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-empty is empty`` () = task {
-    let! sq = TaskSeq.empty<string> |> TaskSeq.toSeqCachedAsync
-    Seq.isEmpty sq |> should be True
-}
+        task {
+            let! sq =
+                createDummyTaskSeq 10
+                |> TaskSeq.collect (fun _ -> TaskSeq.ofSeq Seq.empty)
+                |> TaskSeq.toSeqCachedAsync
+
+            Seq.isEmpty sq |> should be True
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-collectSeq with empty sequences`` () =
+        logStart output
+
+        task {
+            let! sq =
+                createDummyTaskSeq 10
+                |> TaskSeq.collectSeq (fun _ -> Seq.empty<int>)
+                |> TaskSeq.toSeqCachedAsync
+
+            Seq.isEmpty sq |> should be True
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-empty is empty`` () =
+        logStart output
+
+        task {
+            let! sq = TaskSeq.empty<string> |> TaskSeq.toSeqCachedAsync
+            Seq.isEmpty sq |> should be True
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Filter
+namespace FSharpy.Tests
 
 open System
 open Xunit
@@ -7,47 +7,62 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-filter on an empty sequence`` () = task {
-    let! empty =
-        TaskSeq.empty
-        |> TaskSeq.filter ((=) 12)
-        |> TaskSeq.toListAsync
 
-    List.isEmpty empty |> should be True
-}
+type Filter(output) =
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-filterAsync on an empty sequence`` () = task {
-    let! empty =
-        TaskSeq.empty
-        |> TaskSeq.filterAsync (fun x -> task { return x = 12 })
-        |> TaskSeq.toListAsync
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-filter on an empty sequence`` () =
+        logStart output
 
-    List.isEmpty empty |> should be True
-}
+        task {
+            let! empty =
+                TaskSeq.empty
+                |> TaskSeq.filter ((=) 12)
+                |> TaskSeq.toListAsync
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-filter filters correctly`` () = task {
-    let! alphabet =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.filter ((<=) 26) // lambda of '>' etc inverts order of args, so this means 'greater than'
-        |> TaskSeq.map char
-        |> TaskSeq.map ((+) '@')
-        |> TaskSeq.toArrayAsync
+            List.isEmpty empty |> should be True
+        }
 
-    // we filtered all digits above-or-equal-to 26
-    String alphabet |> should equal "Z[\]^_`abcdefghijklmnopqr"
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-filterAsync on an empty sequence`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-filterAsync filters correctly`` () = task {
-    let! alphabet =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.filterAsync (fun x -> task { return x <= 26 })
-        |> TaskSeq.map char
-        |> TaskSeq.map ((+) '@')
-        |> TaskSeq.toArrayAsync
+        task {
+            let! empty =
+                TaskSeq.empty
+                |> TaskSeq.filterAsync (fun x -> task { return x = 12 })
+                |> TaskSeq.toListAsync
 
-    String alphabet |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-}
+            List.isEmpty empty |> should be True
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-filter filters correctly`` () =
+        logStart output
+
+        task {
+            let! alphabet =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.filter ((<=) 26) // lambda of '>' etc inverts order of args, so this means 'greater than'
+                |> TaskSeq.map char
+                |> TaskSeq.map ((+) '@')
+                |> TaskSeq.toArrayAsync
+
+            // we filtered all digits above-or-equal-to 26
+            String alphabet |> should equal "Z[\]^_`abcdefghijklmnopqr"
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-filterAsync filters correctly`` () =
+        logStart output
+
+        task {
+            let! alphabet =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.filterAsync (fun x -> task { return x <= 26 })
+                |> TaskSeq.map char
+                |> TaskSeq.map ((+) '@')
+                |> TaskSeq.toArrayAsync
+
+            String alphabet |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
@@ -7,7 +7,7 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-filter on an empty sequence`` () = task {
     let! empty =
         TaskSeq.empty
@@ -17,7 +17,7 @@ let ``TaskSeq-filter on an empty sequence`` () = task {
     List.isEmpty empty |> should be True
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-filterAsync on an empty sequence`` () = task {
     let! empty =
         TaskSeq.empty
@@ -27,7 +27,7 @@ let ``TaskSeq-filterAsync on an empty sequence`` () = task {
     List.isEmpty empty |> should be True
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-filter filters correctly`` () = task {
     let! alphabet =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -40,7 +40,7 @@ let ``TaskSeq-filter filters correctly`` () = task {
     String alphabet |> should equal "Z[\]^_`abcdefghijklmnopqr"
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-filterAsync filters correctly`` () = task {
     let! alphabet =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
@@ -10,7 +10,7 @@ open FSharpy
 
 type Filter(output) =
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-filter on an empty sequence`` () =
         logStart output
 
@@ -23,7 +23,7 @@ type Filter(output) =
             List.isEmpty empty |> should be True
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-filterAsync on an empty sequence`` () =
         logStart output
 
@@ -36,7 +36,7 @@ type Filter(output) =
             List.isEmpty empty |> should be True
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-filter filters correctly`` () =
         logStart output
 
@@ -52,7 +52,7 @@ type Filter(output) =
             String alphabet |> should equal "Z[\]^_`abcdefghijklmnopqr"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-filterAsync filters correctly`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Find.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Find.Tests.fs
@@ -13,19 +13,19 @@ open System.Collections.Generic
 // the tryXXX versions are at the bottom half
 //
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-find on an empty sequence raises KeyNotFoundException`` () = task {
     fun () -> TaskSeq.empty |> TaskSeq.find ((=) 12) |> Task.ignore
     |> should throwAsyncExact typeof<KeyNotFoundException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-find on an empty sequence raises KeyNotFoundException - variant`` () = task {
     fun () -> taskSeq { do () } |> TaskSeq.find ((=) 12) |> Task.ignore
     |> should throwAsyncExact typeof<KeyNotFoundException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-findAsync on an empty sequence raises KeyNotFoundException`` () = task {
     fun () ->
         TaskSeq.empty
@@ -34,7 +34,7 @@ let ``TaskSeq-findAsync on an empty sequence raises KeyNotFoundException`` () = 
     |> should throwAsyncExact typeof<KeyNotFoundException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-find sad path raises KeyNotFoundException`` () = task {
     fun () ->
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -44,7 +44,7 @@ let ``TaskSeq-find sad path raises KeyNotFoundException`` () = task {
     |> should throwAsyncExact typeof<KeyNotFoundException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-findAsync sad path raises KeyNotFoundException`` () = task {
     fun () ->
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -54,7 +54,7 @@ let ``TaskSeq-findAsync sad path raises KeyNotFoundException`` () = task {
     |> should throwAsyncExact typeof<KeyNotFoundException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-find sad path raises KeyNotFoundException variant`` () = task {
     fun () ->
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -64,7 +64,7 @@ let ``TaskSeq-find sad path raises KeyNotFoundException variant`` () = task {
     |> should throwAsyncExact typeof<KeyNotFoundException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-findAsync sad path raises KeyNotFoundException variant`` () = task {
     fun () ->
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -75,7 +75,7 @@ let ``TaskSeq-findAsync sad path raises KeyNotFoundException variant`` () = task
 }
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-find happy path middle of seq`` () = task {
     let! twentyFive =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -84,7 +84,7 @@ let ``TaskSeq-find happy path middle of seq`` () = task {
     twentyFive |> should equal 25
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-findAsync happy path middle of seq`` () = task {
     let! twentyFive =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -93,7 +93,7 @@ let ``TaskSeq-findAsync happy path middle of seq`` () = task {
     twentyFive |> should equal 25
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-find happy path first item of seq`` () = task {
     let! first =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -102,7 +102,7 @@ let ``TaskSeq-find happy path first item of seq`` () = task {
     first |> should equal 1
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-findAsync happy path first item of seq`` () = task {
     let! first =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -111,7 +111,7 @@ let ``TaskSeq-findAsync happy path first item of seq`` () = task {
     first |> should equal 1
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-find happy path last item of seq`` () = task {
     let! last =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -120,7 +120,7 @@ let ``TaskSeq-find happy path last item of seq`` () = task {
     last |> should equal 50
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-findAsync happy path last item of seq`` () = task {
     let! last =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -134,13 +134,13 @@ let ``TaskSeq-findAsync happy path last item of seq`` () = task {
 // TaskSeq.tryFindAsync
 //
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryFind on an empty sequence returns None`` () = task {
     let! nothing = TaskSeq.empty |> TaskSeq.tryFind ((=) 12)
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryFindAsync on an empty sequence returns None`` () = task {
     let! nothing =
         TaskSeq.empty
@@ -149,7 +149,7 @@ let ``TaskSeq-tryFindAsync on an empty sequence returns None`` () = task {
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryFind sad path returns None`` () = task {
     let! nothing =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -158,7 +158,7 @@ let ``TaskSeq-tryFind sad path returns None`` () = task {
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryFindAsync sad path return None`` () = task {
     let! nothing =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -167,7 +167,7 @@ let ``TaskSeq-tryFindAsync sad path return None`` () = task {
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryFind sad path returns None variant`` () = task {
     let! nothing =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -176,7 +176,7 @@ let ``TaskSeq-tryFind sad path returns None variant`` () = task {
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryFindAsync sad path return None - variant`` () = task {
     let! nothing =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -186,7 +186,7 @@ let ``TaskSeq-tryFindAsync sad path return None - variant`` () = task {
 }
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryFind happy path middle of seq`` () = task {
     let! twentyFive =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -196,7 +196,7 @@ let ``TaskSeq-tryFind happy path middle of seq`` () = task {
     twentyFive |> should equal (Some 25)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryFindAsync happy path middle of seq`` () = task {
     let! twentyFive =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -206,7 +206,7 @@ let ``TaskSeq-tryFindAsync happy path middle of seq`` () = task {
     twentyFive |> should equal (Some 25)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryFind happy path first item of seq`` () = task {
     let! first =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -216,7 +216,7 @@ let ``TaskSeq-tryFind happy path first item of seq`` () = task {
     first |> should equal (Some 1)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryFindAsync happy path first item of seq`` () = task {
     let! first =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -226,7 +226,7 @@ let ``TaskSeq-tryFindAsync happy path first item of seq`` () = task {
     first |> should equal (Some 1)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryFind happy path last item of seq`` () = task {
     let! last =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -236,7 +236,7 @@ let ``TaskSeq-tryFind happy path last item of seq`` () = task {
     last |> should equal (Some 50)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryFindAsync happy path last item of seq`` () = task {
     let! last =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Find.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Find.Tests.fs
@@ -16,7 +16,7 @@ type Find(output) =
     // the tryXXX versions are at the bottom half
     //
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-find on an empty sequence raises KeyNotFoundException`` () =
         logStart output
 
@@ -25,7 +25,7 @@ type Find(output) =
             |> should throwAsyncExact typeof<KeyNotFoundException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-find on an empty sequence raises KeyNotFoundException - variant`` () =
         logStart output
 
@@ -34,7 +34,7 @@ type Find(output) =
             |> should throwAsyncExact typeof<KeyNotFoundException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-findAsync on an empty sequence raises KeyNotFoundException`` () =
         logStart output
 
@@ -46,7 +46,7 @@ type Find(output) =
             |> should throwAsyncExact typeof<KeyNotFoundException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-find sad path raises KeyNotFoundException`` () =
         logStart output
 
@@ -59,7 +59,7 @@ type Find(output) =
             |> should throwAsyncExact typeof<KeyNotFoundException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-findAsync sad path raises KeyNotFoundException`` () =
         logStart output
 
@@ -72,7 +72,7 @@ type Find(output) =
             |> should throwAsyncExact typeof<KeyNotFoundException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-find sad path raises KeyNotFoundException variant`` () =
         logStart output
 
@@ -85,7 +85,7 @@ type Find(output) =
             |> should throwAsyncExact typeof<KeyNotFoundException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-findAsync sad path raises KeyNotFoundException variant`` () =
         logStart output
 
@@ -99,7 +99,7 @@ type Find(output) =
         }
 
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-find happy path middle of seq`` () =
         logStart output
 
@@ -111,7 +111,7 @@ type Find(output) =
             twentyFive |> should equal 25
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-findAsync happy path middle of seq`` () =
         logStart output
 
@@ -123,7 +123,7 @@ type Find(output) =
             twentyFive |> should equal 25
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-find happy path first item of seq`` () =
         logStart output
 
@@ -135,7 +135,7 @@ type Find(output) =
             first |> should equal 1
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-findAsync happy path first item of seq`` () =
         logStart output
 
@@ -147,7 +147,7 @@ type Find(output) =
             first |> should equal 1
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-find happy path last item of seq`` () =
         logStart output
 
@@ -159,7 +159,7 @@ type Find(output) =
             last |> should equal 50
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-findAsync happy path last item of seq`` () =
         logStart output
 
@@ -176,7 +176,7 @@ type Find(output) =
     // TaskSeq.tryFindAsync
     //
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryFind on an empty sequence returns None`` () =
         logStart output
 
@@ -185,7 +185,7 @@ type Find(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryFindAsync on an empty sequence returns None`` () =
         logStart output
 
@@ -197,7 +197,7 @@ type Find(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryFind sad path returns None`` () =
         logStart output
 
@@ -209,7 +209,7 @@ type Find(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryFindAsync sad path return None`` () =
         logStart output
 
@@ -221,7 +221,7 @@ type Find(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryFind sad path returns None variant`` () =
         logStart output
 
@@ -233,7 +233,7 @@ type Find(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryFindAsync sad path return None - variant`` () =
         logStart output
 
@@ -246,7 +246,7 @@ type Find(output) =
         }
 
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryFind happy path middle of seq`` () =
         logStart output
 
@@ -259,7 +259,7 @@ type Find(output) =
             twentyFive |> should equal (Some 25)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryFindAsync happy path middle of seq`` () =
         logStart output
 
@@ -272,7 +272,7 @@ type Find(output) =
             twentyFive |> should equal (Some 25)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryFind happy path first item of seq`` () =
         logStart output
 
@@ -285,7 +285,7 @@ type Find(output) =
             first |> should equal (Some 1)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryFindAsync happy path first item of seq`` () =
         logStart output
 
@@ -298,7 +298,7 @@ type Find(output) =
             first |> should equal (Some 1)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryFind happy path last item of seq`` () =
         logStart output
 
@@ -311,7 +311,7 @@ type Find(output) =
             last |> should equal (Some 50)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryFindAsync happy path last item of seq`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Find.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Find.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Find
+namespace FSharpy.Tests
 
 open Xunit
 open FsUnit.Xunit
@@ -7,241 +7,319 @@ open FsToolkit.ErrorHandling
 open FSharpy
 open System.Collections.Generic
 
-//
-// TaskSeq.find
-// TaskSeq.findAsync
-// the tryXXX versions are at the bottom half
-//
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-find on an empty sequence raises KeyNotFoundException`` () = task {
-    fun () -> TaskSeq.empty |> TaskSeq.find ((=) 12) |> Task.ignore
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
+type Find(output) =
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-find on an empty sequence raises KeyNotFoundException - variant`` () = task {
-    fun () -> taskSeq { do () } |> TaskSeq.find ((=) 12) |> Task.ignore
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
+    //
+    // TaskSeq.find
+    // TaskSeq.findAsync
+    // the tryXXX versions are at the bottom half
+    //
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-findAsync on an empty sequence raises KeyNotFoundException`` () = task {
-    fun () ->
-        TaskSeq.empty
-        |> TaskSeq.findAsync (fun x -> task { return x = 12 })
-        |> Task.ignore
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-find on an empty sequence raises KeyNotFoundException`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-find sad path raises KeyNotFoundException`` () = task {
-    fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.find ((=) 0) // dummy tasks sequence starts at 1
-        |> Task.ignore
+        task {
+            fun () -> TaskSeq.empty |> TaskSeq.find ((=) 12) |> Task.ignore
+            |> should throwAsyncExact typeof<KeyNotFoundException>
+        }
 
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-find on an empty sequence raises KeyNotFoundException - variant`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-findAsync sad path raises KeyNotFoundException`` () = task {
-    fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.findAsync (fun x -> task { return x = 0 }) // dummy tasks sequence starts at 1
-        |> Task.ignore
+        task {
+            fun () -> taskSeq { do () } |> TaskSeq.find ((=) 12) |> Task.ignore
+            |> should throwAsyncExact typeof<KeyNotFoundException>
+        }
 
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-findAsync on an empty sequence raises KeyNotFoundException`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-find sad path raises KeyNotFoundException variant`` () = task {
-    fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.find ((=) 51) // dummy tasks sequence ends at 50
-        |> Task.ignore
+        task {
+            fun () ->
+                TaskSeq.empty
+                |> TaskSeq.findAsync (fun x -> task { return x = 12 })
+                |> Task.ignore
+            |> should throwAsyncExact typeof<KeyNotFoundException>
+        }
 
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-find sad path raises KeyNotFoundException`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-findAsync sad path raises KeyNotFoundException variant`` () = task {
-    fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.findAsync (fun x -> task { return x = 51 }) // dummy tasks sequence ends at 50
-        |> Task.ignore
+        task {
+            fun () ->
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.find ((=) 0) // dummy tasks sequence starts at 1
+                |> Task.ignore
 
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
+            |> should throwAsyncExact typeof<KeyNotFoundException>
+        }
 
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-findAsync sad path raises KeyNotFoundException`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-find happy path middle of seq`` () = task {
-    let! twentyFive =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.find (fun x -> x < 26 && x > 24)
+        task {
+            fun () ->
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.findAsync (fun x -> task { return x = 0 }) // dummy tasks sequence starts at 1
+                |> Task.ignore
 
-    twentyFive |> should equal 25
-}
+            |> should throwAsyncExact typeof<KeyNotFoundException>
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-findAsync happy path middle of seq`` () = task {
-    let! twentyFive =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.findAsync (fun x -> task { return x < 26 && x > 24 })
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-find sad path raises KeyNotFoundException variant`` () =
+        logStart output
 
-    twentyFive |> should equal 25
-}
+        task {
+            fun () ->
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.find ((=) 51) // dummy tasks sequence ends at 50
+                |> Task.ignore
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-find happy path first item of seq`` () = task {
-    let! first =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.find ((=) 1) // dummy tasks seq starts at 1
+            |> should throwAsyncExact typeof<KeyNotFoundException>
+        }
 
-    first |> should equal 1
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-findAsync sad path raises KeyNotFoundException variant`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-findAsync happy path first item of seq`` () = task {
-    let! first =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.findAsync (fun x -> task { return x = 1 }) // dummy tasks seq starts at 1
+        task {
+            fun () ->
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.findAsync (fun x -> task { return x = 51 }) // dummy tasks sequence ends at 50
+                |> Task.ignore
 
-    first |> should equal 1
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-find happy path last item of seq`` () = task {
-    let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.find ((=) 50) // dummy tasks seq ends at 50
-
-    last |> should equal 50
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-findAsync happy path last item of seq`` () = task {
-    let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.findAsync (fun x -> task { return x = 50 }) // dummy tasks seq ends at 50
-
-    last |> should equal 50
-}
-
-//
-// TaskSeq.tryFind
-// TaskSeq.tryFindAsync
-//
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryFind on an empty sequence returns None`` () = task {
-    let! nothing = TaskSeq.empty |> TaskSeq.tryFind ((=) 12)
-    nothing |> should be None'
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryFindAsync on an empty sequence returns None`` () = task {
-    let! nothing =
-        TaskSeq.empty
-        |> TaskSeq.tryFindAsync (fun x -> task { return x = 12 })
-
-    nothing |> should be None'
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryFind sad path returns None`` () = task {
-    let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFind ((=) 0) // dummy tasks sequence starts at 1
-
-    nothing |> should be None'
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryFindAsync sad path return None`` () = task {
-    let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFindAsync (fun x -> task { return x = 0 }) // dummy tasks sequence starts at 1
-
-    nothing |> should be None'
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryFind sad path returns None variant`` () = task {
-    let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFind ((<=) 51) // dummy tasks sequence ends at 50 (inverted sign in lambda!)
-
-    nothing |> should be None'
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryFindAsync sad path return None - variant`` () = task {
-    let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFindAsync (fun x -> task { return x >= 51 }) // dummy tasks sequence ends at 50
-
-    nothing |> should be None'
-}
+            |> should throwAsyncExact typeof<KeyNotFoundException>
+        }
 
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryFind happy path middle of seq`` () = task {
-    let! twentyFive =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFind (fun x -> x < 26 && x > 24)
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-find happy path middle of seq`` () =
+        logStart output
 
-    twentyFive |> should be Some'
-    twentyFive |> should equal (Some 25)
-}
+        task {
+            let! twentyFive =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.find (fun x -> x < 26 && x > 24)
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryFindAsync happy path middle of seq`` () = task {
-    let! twentyFive =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFindAsync (fun x -> task { return x < 26 && x > 24 })
+            twentyFive |> should equal 25
+        }
 
-    twentyFive |> should be Some'
-    twentyFive |> should equal (Some 25)
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-findAsync happy path middle of seq`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryFind happy path first item of seq`` () = task {
-    let! first =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFind ((=) 1) // dummy tasks seq starts at 1
+        task {
+            let! twentyFive =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.findAsync (fun x -> task { return x < 26 && x > 24 })
 
-    first |> should be Some'
-    first |> should equal (Some 1)
-}
+            twentyFive |> should equal 25
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryFindAsync happy path first item of seq`` () = task {
-    let! first =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFindAsync (fun x -> task { return x = 1 }) // dummy tasks seq starts at 1
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-find happy path first item of seq`` () =
+        logStart output
 
-    first |> should be Some'
-    first |> should equal (Some 1)
-}
+        task {
+            let! first =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.find ((=) 1) // dummy tasks seq starts at 1
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryFind happy path last item of seq`` () = task {
-    let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFind ((=) 50) // dummy tasks seq ends at 50
+            first |> should equal 1
+        }
 
-    last |> should be Some'
-    last |> should equal (Some 50)
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-findAsync happy path first item of seq`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryFindAsync happy path last item of seq`` () = task {
-    let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFindAsync (fun x -> task { return x = 50 }) // dummy tasks seq ends at 50
+        task {
+            let! first =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.findAsync (fun x -> task { return x = 1 }) // dummy tasks seq starts at 1
 
-    last |> should be Some'
-    last |> should equal (Some 50)
-}
+            first |> should equal 1
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-find happy path last item of seq`` () =
+        logStart output
+
+        task {
+            let! last =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.find ((=) 50) // dummy tasks seq ends at 50
+
+            last |> should equal 50
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-findAsync happy path last item of seq`` () =
+        logStart output
+
+        task {
+            let! last =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.findAsync (fun x -> task { return x = 50 }) // dummy tasks seq ends at 50
+
+            last |> should equal 50
+        }
+
+    //
+    // TaskSeq.tryFind
+    // TaskSeq.tryFindAsync
+    //
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryFind on an empty sequence returns None`` () =
+        logStart output
+
+        task {
+            let! nothing = TaskSeq.empty |> TaskSeq.tryFind ((=) 12)
+            nothing |> should be None'
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryFindAsync on an empty sequence returns None`` () =
+        logStart output
+
+        task {
+            let! nothing =
+                TaskSeq.empty
+                |> TaskSeq.tryFindAsync (fun x -> task { return x = 12 })
+
+            nothing |> should be None'
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryFind sad path returns None`` () =
+        logStart output
+
+        task {
+            let! nothing =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryFind ((=) 0) // dummy tasks sequence starts at 1
+
+            nothing |> should be None'
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryFindAsync sad path return None`` () =
+        logStart output
+
+        task {
+            let! nothing =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryFindAsync (fun x -> task { return x = 0 }) // dummy tasks sequence starts at 1
+
+            nothing |> should be None'
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryFind sad path returns None variant`` () =
+        logStart output
+
+        task {
+            let! nothing =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryFind ((<=) 51) // dummy tasks sequence ends at 50 (inverted sign in lambda!)
+
+            nothing |> should be None'
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryFindAsync sad path return None - variant`` () =
+        logStart output
+
+        task {
+            let! nothing =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryFindAsync (fun x -> task { return x >= 51 }) // dummy tasks sequence ends at 50
+
+            nothing |> should be None'
+        }
+
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryFind happy path middle of seq`` () =
+        logStart output
+
+        task {
+            let! twentyFive =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryFind (fun x -> x < 26 && x > 24)
+
+            twentyFive |> should be Some'
+            twentyFive |> should equal (Some 25)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryFindAsync happy path middle of seq`` () =
+        logStart output
+
+        task {
+            let! twentyFive =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryFindAsync (fun x -> task { return x < 26 && x > 24 })
+
+            twentyFive |> should be Some'
+            twentyFive |> should equal (Some 25)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryFind happy path first item of seq`` () =
+        logStart output
+
+        task {
+            let! first =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryFind ((=) 1) // dummy tasks seq starts at 1
+
+            first |> should be Some'
+            first |> should equal (Some 1)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryFindAsync happy path first item of seq`` () =
+        logStart output
+
+        task {
+            let! first =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryFindAsync (fun x -> task { return x = 1 }) // dummy tasks seq starts at 1
+
+            first |> should be Some'
+            first |> should equal (Some 1)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryFind happy path last item of seq`` () =
+        logStart output
+
+        task {
+            let! last =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryFind ((=) 50) // dummy tasks seq ends at 50
+
+            last |> should be Some'
+            last |> should equal (Some 50)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryFindAsync happy path last item of seq`` () =
+        logStart output
+
+        task {
+            let! last =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryFindAsync (fun x -> task { return x = 50 }) // dummy tasks seq ends at 50
+
+            last |> should be Some'
+            last |> should equal (Some 50)
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
@@ -8,7 +8,7 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-fold folds with every item`` () = task {
     let! alphabet =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 26
@@ -18,7 +18,7 @@ let ``TaskSeq-fold folds with every item`` () = task {
     |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-foldAsync folds with every item`` () = task {
     let! alphabet =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 26
@@ -30,7 +30,7 @@ let ``TaskSeq-foldAsync folds with every item`` () = task {
     |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-fold takes state on empty IAsyncEnumberable`` () = task {
     let! empty =
         TaskSeq.empty
@@ -39,7 +39,7 @@ let ``TaskSeq-fold takes state on empty IAsyncEnumberable`` () = task {
     empty |> should equal '_'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-foldAsync takes state on empty IAsyncEnumerable`` () = task {
     let! alphabet =
         TaskSeq.empty

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
@@ -9,7 +9,7 @@ open FSharpy
 
 type Fold(output) =
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-fold folds with every item`` () =
         logStart output
 
@@ -22,7 +22,7 @@ type Fold(output) =
             |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-foldAsync folds with every item`` () =
         logStart output
 
@@ -37,7 +37,7 @@ type Fold(output) =
             |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-fold takes state on empty IAsyncEnumberable`` () =
         logStart output
 
@@ -49,7 +49,7 @@ type Fold(output) =
             empty |> should equal '_'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-foldAsync takes state on empty IAsyncEnumerable`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Fold
+namespace FSharpy.Tests
 
 open System.Text
 open Xunit
@@ -7,43 +7,56 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+type Fold(output) =
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-fold folds with every item`` () = task {
-    let! alphabet =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 26
-        |> TaskSeq.fold (fun (state: StringBuilder) item -> state.Append(char item + '@')) (StringBuilder())
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-fold folds with every item`` () =
+        logStart output
 
-    alphabet.ToString()
-    |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-}
+        task {
+            let! alphabet =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 26
+                |> TaskSeq.fold (fun (state: StringBuilder) item -> state.Append(char item + '@')) (StringBuilder())
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-foldAsync folds with every item`` () = task {
-    let! alphabet =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 26
-        |> TaskSeq.foldAsync
-            (fun (state: StringBuilder) item -> task { return state.Append(char item + '@') })
-            (StringBuilder())
+            alphabet.ToString()
+            |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }
 
-    alphabet.ToString()
-    |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-foldAsync folds with every item`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-fold takes state on empty IAsyncEnumberable`` () = task {
-    let! empty =
-        TaskSeq.empty
-        |> TaskSeq.fold (fun _ item -> char (item + 64)) '_'
+        task {
+            let! alphabet =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 26
+                |> TaskSeq.foldAsync
+                    (fun (state: StringBuilder) item -> task { return state.Append(char item + '@') })
+                    (StringBuilder())
 
-    empty |> should equal '_'
-}
+            alphabet.ToString()
+            |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-foldAsync takes state on empty IAsyncEnumerable`` () = task {
-    let! alphabet =
-        TaskSeq.empty
-        |> TaskSeq.foldAsync (fun _ item -> task { return char (item + 64) }) '_'
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-fold takes state on empty IAsyncEnumberable`` () =
+        logStart output
 
-    alphabet |> should equal '_'
-}
+        task {
+            let! empty =
+                TaskSeq.empty
+                |> TaskSeq.fold (fun _ item -> char (item + 64)) '_'
+
+            empty |> should equal '_'
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-foldAsync takes state on empty IAsyncEnumerable`` () =
+        logStart output
+
+        task {
+            let! alphabet =
+                TaskSeq.empty
+                |> TaskSeq.foldAsync (fun _ item -> task { return char (item + 64) }) '_'
+
+            alphabet |> should equal '_'
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
@@ -9,7 +9,7 @@ open FSharpy
 
 type Head(output) =
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-head throws on empty sequences`` () =
         logStart output
 
@@ -18,7 +18,7 @@ type Head(output) =
             |> should throwAsyncExact typeof<ArgumentException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-head throws on empty sequences - variant`` () =
         logStart output
 
@@ -27,7 +27,7 @@ type Head(output) =
             |> should throwAsyncExact typeof<ArgumentException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryHead returns None on empty sequences`` () =
         logStart output
 
@@ -36,7 +36,7 @@ type Head(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-head gets the first item in a longer sequence`` () =
         logStart output
 
@@ -46,7 +46,7 @@ type Head(output) =
             head |> should equal 1
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-head gets the only item in a singleton sequence`` () =
         logStart output
 
@@ -55,7 +55,7 @@ type Head(output) =
             head |> should equal 10
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryHead gets the first item in a longer sequence`` () =
         logStart output
 
@@ -68,7 +68,7 @@ type Head(output) =
             head |> should equal (Some 1)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryHead gets the only item in a singleton sequence`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Head
+namespace FSharpy.Tests
 
 open System
 open Xunit
@@ -7,51 +7,73 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+type Head(output) =
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-head throws on empty sequences`` () = task {
-    fun () -> TaskSeq.empty<string> |> TaskSeq.head |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-head throws on empty sequences`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-head throws on empty sequences - variant`` () = task {
-    fun () -> taskSeq { do () } |> TaskSeq.head |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+        task {
+            fun () -> TaskSeq.empty<string> |> TaskSeq.head |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryHead returns None on empty sequences`` () = task {
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryHead
-    nothing |> should be None'
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-head throws on empty sequences - variant`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-head gets the first item in a longer sequence`` () = task {
-    let! head = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50 |> TaskSeq.head
+        task {
+            fun () -> taskSeq { do () } |> TaskSeq.head |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
+        }
 
-    head |> should equal 1
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryHead returns None on empty sequences`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-head gets the only item in a singleton sequence`` () = task {
-    let! head = taskSeq { yield 10 } |> TaskSeq.head
-    head |> should equal 10
-}
+        task {
+            let! nothing = TaskSeq.empty<string> |> TaskSeq.tryHead
+            nothing |> should be None'
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryHead gets the first item in a longer sequence`` () = task {
-    let! head =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryHead
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-head gets the first item in a longer sequence`` () =
+        logStart output
 
-    head |> should be Some'
-    head |> should equal (Some 1)
-}
+        task {
+            let! head = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50 |> TaskSeq.head
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryHead gets the only item in a singleton sequence`` () = task {
-    let! head = taskSeq { yield 10 } |> TaskSeq.tryHead
-    head |> should be Some'
-    head |> should equal (Some 10)
-}
+            head |> should equal 1
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-head gets the only item in a singleton sequence`` () =
+        logStart output
+
+        task {
+            let! head = taskSeq { yield 10 } |> TaskSeq.head
+            head |> should equal 10
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryHead gets the first item in a longer sequence`` () =
+        logStart output
+
+        task {
+            let! head =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryHead
+
+            head |> should be Some'
+            head |> should equal (Some 1)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryHead gets the only item in a singleton sequence`` () =
+        logStart output
+
+        task {
+            let! head = taskSeq { yield 10 } |> TaskSeq.tryHead
+            head |> should be Some'
+            head |> should equal (Some 10)
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
@@ -8,38 +8,38 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-head throws on empty sequences`` () = task {
     fun () -> TaskSeq.empty<string> |> TaskSeq.head |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-head throws on empty sequences - variant`` () = task {
     fun () -> taskSeq { do () } |> TaskSeq.head |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryHead returns None on empty sequences`` () = task {
     let! nothing = TaskSeq.empty<string> |> TaskSeq.tryHead
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-head gets the first item in a longer sequence`` () = task {
     let! head = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50 |> TaskSeq.head
 
     head |> should equal 1
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-head gets the only item in a singleton sequence`` () = task {
     let! head = taskSeq { yield 10 } |> TaskSeq.head
     head |> should equal 10
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryHead gets the first item in a longer sequence`` () = task {
     let! head =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -49,7 +49,7 @@ let ``TaskSeq-tryHead gets the first item in a longer sequence`` () = task {
     head |> should equal (Some 1)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryHead gets the only item in a singleton sequence`` () = task {
     let! head = taskSeq { yield 10 } |> TaskSeq.tryHead
     head |> should be Some'

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
@@ -8,19 +8,19 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-item throws on empty sequences`` () = task {
     fun () -> TaskSeq.empty<string> |> TaskSeq.item 0 |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-item throws on empty sequence - variant`` () = task {
     fun () -> taskSeq { do () } |> TaskSeq.item 50000 |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-item throws when not found`` () = task {
     fun () ->
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -29,7 +29,7 @@ let ``TaskSeq-item throws when not found`` () = task {
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-item throws when not found - variant`` () = task {
     fun () ->
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -38,13 +38,13 @@ let ``TaskSeq-item throws when not found - variant`` () = task {
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-item throws when accessing 2nd item in singleton sequence`` () = task {
     fun () -> taskSeq { yield 10 } |> TaskSeq.item 1 |> Task.ignore // zero-based!
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-item always throws with negative values`` () = task {
     let make50 () = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
 
@@ -70,19 +70,19 @@ let ``TaskSeq-item always throws with negative values`` () = task {
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem returns None on empty sequences`` () = task {
     let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem 0
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem returns None on empty sequence - variant`` () = task {
     let! nothing = taskSeq { do () } |> TaskSeq.tryItem 50000
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem returns None when not found`` () = task {
     let! nothing =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -91,7 +91,7 @@ let ``TaskSeq-tryItem returns None when not found`` () = task {
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem returns None when not found - variant`` () = task {
     let! nothing =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -100,13 +100,13 @@ let ``TaskSeq-tryItem returns None when not found - variant`` () = task {
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem returns None when accessing 2nd item in singleton sequence`` () = task {
     let! nothing = taskSeq { yield 10 } |> TaskSeq.tryItem 1 // zero-based!
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem returns None throws with negative values`` () = task {
     let make50 () = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
 
@@ -129,7 +129,7 @@ let ``TaskSeq-tryItem returns None throws with negative values`` () = task {
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-item can get the first item in a longer sequence`` () = task {
     let! head =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -138,7 +138,7 @@ let ``TaskSeq-item can get the first item in a longer sequence`` () = task {
     head |> should equal 1
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-item can get the last item in a longer sequence`` () = task {
     let! head =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -147,13 +147,13 @@ let ``TaskSeq-item can get the last item in a longer sequence`` () = task {
     head |> should equal 50
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-item can get the first item in a singleton sequence`` () = task {
     let! head = taskSeq { yield 10 } |> TaskSeq.item 0 // zero-based index!
     head |> should equal 10
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem can get the first item in a longer sequence`` () = task {
     let! head =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -163,7 +163,7 @@ let ``TaskSeq-tryItem can get the first item in a longer sequence`` () = task {
     head |> should equal (Some 1)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem in a very long sequence (5_000 items - slow variant)`` () = task {
     let! head = createDummyDirectTaskSeq 5_001 |> TaskSeq.tryItem 5_000 // zero-based!
 
@@ -171,7 +171,7 @@ let ``TaskSeq-tryItem in a very long sequence (5_000 items - slow variant)`` () 
     head |> should equal (Some 5_001)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem in a very long sequence (50_000 items - slow variant)`` () = task {
     let! head = createDummyDirectTaskSeq 50_001 |> TaskSeq.tryItem 50_000 // zero-based!
 
@@ -179,7 +179,7 @@ let ``TaskSeq-tryItem in a very long sequence (50_000 items - slow variant)`` ()
     head |> should equal (Some 50_001)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem in a very long sequence (50_000 items - fast variant)`` () = task {
     let! head =
         // using taskSeq instead of the delayed-task approach above, which creates an extra closure for each
@@ -194,7 +194,7 @@ let ``TaskSeq-tryItem in a very long sequence (50_000 items - fast variant)`` ()
     head |> should equal (Some 50_000)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem in a very long sequence (50_000 items - using sync Seq)`` () = task {
     // this test is just for smoke-test perf comparison with TaskSeq above
     let head =
@@ -208,7 +208,7 @@ let ``TaskSeq-tryItem in a very long sequence (50_000 items - using sync Seq)`` 
     head |> should equal (Some 50_000)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem in a very long sequence (500_000 items - fast variant)`` () = task {
     let! head =
         taskSeq {
@@ -221,7 +221,7 @@ let ``TaskSeq-tryItem in a very long sequence (500_000 items - fast variant)`` (
     head |> should equal (Some 500_000)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem in a very long sequence (500_000 items - using sync Seq)`` () = task {
     // this test is just for smoke-test perf comparison with TaskSeq above
     let head =
@@ -235,7 +235,7 @@ let ``TaskSeq-tryItem in a very long sequence (500_000 items - using sync Seq)``
     head |> should equal (Some 500_000)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryItem gets the first item in a singleton sequence`` () = task {
     let! head = taskSeq { yield 10 } |> TaskSeq.tryItem 0 // zero-based!
     head |> should be Some'

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Item
+namespace FSharpy.Tests
 
 open System
 open Xunit
@@ -7,237 +7,307 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+type Item(output) =
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-item throws on empty sequences`` () = task {
-    fun () -> TaskSeq.empty<string> |> TaskSeq.item 0 |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-item throws on empty sequences`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-item throws on empty sequence - variant`` () = task {
-    fun () -> taskSeq { do () } |> TaskSeq.item 50000 |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-item throws when not found`` () = task {
-    fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.item 51
-        |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-item throws when not found - variant`` () = task {
-    fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.item Int32.MaxValue
-        |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-item throws when accessing 2nd item in singleton sequence`` () = task {
-    fun () -> taskSeq { yield 10 } |> TaskSeq.item 1 |> Task.ignore // zero-based!
-    |> should throwAsyncExact typeof<ArgumentException>
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-item always throws with negative values`` () = task {
-    let make50 () = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-
-    fun () -> make50 () |> TaskSeq.item -1 |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-
-    fun () -> make50 () |> TaskSeq.item -10000 |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-
-    fun () -> make50 () |> TaskSeq.item Int32.MinValue |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-
-    fun () -> TaskSeq.empty<string> |> TaskSeq.item -1 |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-
-    fun () -> TaskSeq.empty<string> |> TaskSeq.item -10000 |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-
-    fun () ->
-        TaskSeq.empty<string>
-        |> TaskSeq.item Int32.MinValue
-        |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem returns None on empty sequences`` () = task {
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem 0
-    nothing |> should be None'
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem returns None on empty sequence - variant`` () = task {
-    let! nothing = taskSeq { do () } |> TaskSeq.tryItem 50000
-    nothing |> should be None'
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem returns None when not found`` () = task {
-    let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryItem 50 // zero-based index, so a sequence of 50 items has its last item at index 49
-
-    nothing |> should be None'
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem returns None when not found - variant`` () = task {
-    let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryItem Int32.MaxValue
-
-    nothing |> should be None'
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem returns None when accessing 2nd item in singleton sequence`` () = task {
-    let! nothing = taskSeq { yield 10 } |> TaskSeq.tryItem 1 // zero-based!
-    nothing |> should be None'
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem returns None throws with negative values`` () = task {
-    let make50 () = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-
-    let! nothing = make50 () |> TaskSeq.tryItem -1
-    nothing |> should be None'
-
-    let! nothing = make50 () |> TaskSeq.tryItem -10000
-    nothing |> should be None'
-
-    let! nothing = make50 () |> TaskSeq.tryItem Int32.MinValue
-    nothing |> should be None'
-
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem -1
-    nothing |> should be None'
-
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem -10000
-    nothing |> should be None'
-
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem Int32.MinValue
-    nothing |> should be None'
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-item can get the first item in a longer sequence`` () = task {
-    let! head =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.item 0
-
-    head |> should equal 1
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-item can get the last item in a longer sequence`` () = task {
-    let! head =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.item 49
-
-    head |> should equal 50
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-item can get the first item in a singleton sequence`` () = task {
-    let! head = taskSeq { yield 10 } |> TaskSeq.item 0 // zero-based index!
-    head |> should equal 10
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem can get the first item in a longer sequence`` () = task {
-    let! head =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryItem 0 // zero-based!
-
-    head |> should be Some'
-    head |> should equal (Some 1)
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem in a very long sequence (5_000 items - slow variant)`` () = task {
-    let! head = createDummyDirectTaskSeq 5_001 |> TaskSeq.tryItem 5_000 // zero-based!
-
-    head |> should be Some'
-    head |> should equal (Some 5_001)
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem in a very long sequence (50_000 items - slow variant)`` () = task {
-    let! head = createDummyDirectTaskSeq 50_001 |> TaskSeq.tryItem 50_000 // zero-based!
-
-    head |> should be Some'
-    head |> should equal (Some 50_001)
-}
-
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem in a very long sequence (50_000 items - fast variant)`` () = task {
-    let! head =
-        // using taskSeq instead of the delayed-task approach above, which creates an extra closure for each
-        // task, we can really see the speed of the 'taskSeq' CE!! This is
-        taskSeq {
-            for i in [ 0..50_000 ] do
-                yield i
+        task {
+            fun () -> TaskSeq.empty<string> |> TaskSeq.item 0 |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
         }
-        |> TaskSeq.tryItem 50_000 // zero-based!
 
-    head |> should be Some'
-    head |> should equal (Some 50_000)
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-item throws on empty sequence - variant`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem in a very long sequence (50_000 items - using sync Seq)`` () = task {
-    // this test is just for smoke-test perf comparison with TaskSeq above
-    let head =
-        seq {
-            for i in [ 0..50_000 ] do
-                yield i
+        task {
+            fun () -> taskSeq { do () } |> TaskSeq.item 50000 |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
         }
-        |> Seq.tryItem 50_000 // zero-based!
 
-    head |> should be Some'
-    head |> should equal (Some 50_000)
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-item throws when not found`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem in a very long sequence (500_000 items - fast variant)`` () = task {
-    let! head =
-        taskSeq {
-            for i in [ 0..500_000 ] do
-                yield i
+        task {
+            fun () ->
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.item 51
+                |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
         }
-        |> TaskSeq.tryItem 500_000 // zero-based!
 
-    head |> should be Some'
-    head |> should equal (Some 500_000)
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-item throws when not found - variant`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem in a very long sequence (500_000 items - using sync Seq)`` () = task {
-    // this test is just for smoke-test perf comparison with TaskSeq above
-    let head =
-        seq {
-            for i in [ 0..500_000 ] do
-                yield i
+        task {
+            fun () ->
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.item Int32.MaxValue
+                |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
         }
-        |> Seq.tryItem 500_000 // zero-based!
 
-    head |> should be Some'
-    head |> should equal (Some 500_000)
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-item throws when accessing 2nd item in singleton sequence`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryItem gets the first item in a singleton sequence`` () = task {
-    let! head = taskSeq { yield 10 } |> TaskSeq.tryItem 0 // zero-based!
-    head |> should be Some'
-    head |> should equal (Some 10)
-}
+        task {
+            fun () -> taskSeq { yield 10 } |> TaskSeq.item 1 |> Task.ignore // zero-based!
+            |> should throwAsyncExact typeof<ArgumentException>
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-item always throws with negative values`` () =
+        logStart output
+
+        task {
+            let make50 () = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+
+            fun () -> make50 () |> TaskSeq.item -1 |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
+
+            fun () -> make50 () |> TaskSeq.item -10000 |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
+
+            fun () -> make50 () |> TaskSeq.item Int32.MinValue |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
+
+            fun () -> TaskSeq.empty<string> |> TaskSeq.item -1 |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
+
+            fun () -> TaskSeq.empty<string> |> TaskSeq.item -10000 |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
+
+            fun () ->
+                TaskSeq.empty<string>
+                |> TaskSeq.item Int32.MinValue
+                |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem returns None on empty sequences`` () =
+        logStart output
+
+        task {
+            let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem 0
+            nothing |> should be None'
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem returns None on empty sequence - variant`` () =
+        logStart output
+
+        task {
+            let! nothing = taskSeq { do () } |> TaskSeq.tryItem 50000
+            nothing |> should be None'
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem returns None when not found`` () =
+        logStart output
+
+        task {
+            let! nothing =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryItem 50 // zero-based index, so a sequence of 50 items has its last item at index 49
+
+            nothing |> should be None'
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem returns None when not found - variant`` () =
+        logStart output
+
+        task {
+            let! nothing =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryItem Int32.MaxValue
+
+            nothing |> should be None'
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem returns None when accessing 2nd item in singleton sequence`` () =
+        logStart output
+
+        task {
+            let! nothing = taskSeq { yield 10 } |> TaskSeq.tryItem 1 // zero-based!
+            nothing |> should be None'
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem returns None throws with negative values`` () =
+        logStart output
+
+        task {
+            let make50 () = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+
+            let! nothing = make50 () |> TaskSeq.tryItem -1
+            nothing |> should be None'
+
+            let! nothing = make50 () |> TaskSeq.tryItem -10000
+            nothing |> should be None'
+
+            let! nothing = make50 () |> TaskSeq.tryItem Int32.MinValue
+            nothing |> should be None'
+
+            let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem -1
+            nothing |> should be None'
+
+            let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem -10000
+            nothing |> should be None'
+
+            let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem Int32.MinValue
+            nothing |> should be None'
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-item can get the first item in a longer sequence`` () =
+        logStart output
+
+        task {
+            let! head =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.item 0
+
+            head |> should equal 1
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-item can get the last item in a longer sequence`` () =
+        logStart output
+
+        task {
+            let! head =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.item 49
+
+            head |> should equal 50
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-item can get the first item in a singleton sequence`` () =
+        logStart output
+
+        task {
+            let! head = taskSeq { yield 10 } |> TaskSeq.item 0 // zero-based index!
+            head |> should equal 10
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem can get the first item in a longer sequence`` () =
+        logStart output
+
+        task {
+            let! head =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryItem 0 // zero-based!
+
+            head |> should be Some'
+            head |> should equal (Some 1)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem in a very long sequence (5_000 items - slow variant)`` () =
+        logStart output
+
+        task {
+            let! head = createDummyDirectTaskSeq 5_001 |> TaskSeq.tryItem 5_000 // zero-based!
+
+            head |> should be Some'
+            head |> should equal (Some 5_001)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem in a very long sequence (50_000 items - slow variant)`` () =
+        logStart output
+
+        task {
+            let! head = createDummyDirectTaskSeq 50_001 |> TaskSeq.tryItem 50_000 // zero-based!
+
+            head |> should be Some'
+            head |> should equal (Some 50_001)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem in a very long sequence (50_000 items - fast variant)`` () =
+        logStart output
+
+        task {
+            let! head =
+                // using taskSeq instead of the delayed-task approach above, which creates an extra closure for each
+                // task, we can really see the speed of the 'taskSeq' CE!! This is
+                taskSeq {
+                    for i in [ 0..50_000 ] do
+                        yield i
+                }
+                |> TaskSeq.tryItem 50_000 // zero-based!
+
+            head |> should be Some'
+            head |> should equal (Some 50_000)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem in a very long sequence (50_000 items - using sync Seq)`` () =
+        logStart output
+
+        task {
+            // this test is just for smoke-test perf comparison with TaskSeq above
+            let head =
+                seq {
+                    for i in [ 0..50_000 ] do
+                        yield i
+                }
+                |> Seq.tryItem 50_000 // zero-based!
+
+            head |> should be Some'
+            head |> should equal (Some 50_000)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem in a very long sequence (500_000 items - fast variant)`` () =
+        logStart output
+
+        task {
+            let! head =
+                taskSeq {
+                    for i in [ 0..500_000 ] do
+                        yield i
+                }
+                |> TaskSeq.tryItem 500_000 // zero-based!
+
+            head |> should be Some'
+            head |> should equal (Some 500_000)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem in a very long sequence (500_000 items - using sync Seq)`` () =
+        logStart output
+
+        task {
+            // this test is just for smoke-test perf comparison with TaskSeq above
+            let head =
+                seq {
+                    for i in [ 0..500_000 ] do
+                        yield i
+                }
+                |> Seq.tryItem 500_000 // zero-based!
+
+            head |> should be Some'
+            head |> should equal (Some 500_000)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryItem gets the first item in a singleton sequence`` () =
+        logStart output
+
+        task {
+            let! head = taskSeq { yield 10 } |> TaskSeq.tryItem 0 // zero-based!
+            head |> should be Some'
+            head |> should equal (Some 10)
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
@@ -9,7 +9,7 @@ open FSharpy
 
 type Item(output) =
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-item throws on empty sequences`` () =
         logStart output
 
@@ -18,7 +18,7 @@ type Item(output) =
             |> should throwAsyncExact typeof<ArgumentException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-item throws on empty sequence - variant`` () =
         logStart output
 
@@ -27,7 +27,7 @@ type Item(output) =
             |> should throwAsyncExact typeof<ArgumentException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-item throws when not found`` () =
         logStart output
 
@@ -39,7 +39,7 @@ type Item(output) =
             |> should throwAsyncExact typeof<ArgumentException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-item throws when not found - variant`` () =
         logStart output
 
@@ -51,7 +51,7 @@ type Item(output) =
             |> should throwAsyncExact typeof<ArgumentException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-item throws when accessing 2nd item in singleton sequence`` () =
         logStart output
 
@@ -60,7 +60,7 @@ type Item(output) =
             |> should throwAsyncExact typeof<ArgumentException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-item always throws with negative values`` () =
         logStart output
 
@@ -89,7 +89,7 @@ type Item(output) =
             |> should throwAsyncExact typeof<ArgumentException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem returns None on empty sequences`` () =
         logStart output
 
@@ -98,7 +98,7 @@ type Item(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem returns None on empty sequence - variant`` () =
         logStart output
 
@@ -107,7 +107,7 @@ type Item(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem returns None when not found`` () =
         logStart output
 
@@ -119,7 +119,7 @@ type Item(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem returns None when not found - variant`` () =
         logStart output
 
@@ -131,7 +131,7 @@ type Item(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem returns None when accessing 2nd item in singleton sequence`` () =
         logStart output
 
@@ -140,7 +140,7 @@ type Item(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem returns None throws with negative values`` () =
         logStart output
 
@@ -166,7 +166,7 @@ type Item(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-item can get the first item in a longer sequence`` () =
         logStart output
 
@@ -178,7 +178,7 @@ type Item(output) =
             head |> should equal 1
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-item can get the last item in a longer sequence`` () =
         logStart output
 
@@ -190,7 +190,7 @@ type Item(output) =
             head |> should equal 50
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-item can get the first item in a singleton sequence`` () =
         logStart output
 
@@ -199,7 +199,7 @@ type Item(output) =
             head |> should equal 10
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem can get the first item in a longer sequence`` () =
         logStart output
 
@@ -212,7 +212,7 @@ type Item(output) =
             head |> should equal (Some 1)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem in a very long sequence (5_000 items - slow variant)`` () =
         logStart output
 
@@ -223,7 +223,7 @@ type Item(output) =
             head |> should equal (Some 5_001)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem in a very long sequence (50_000 items - slow variant)`` () =
         logStart output
 
@@ -234,7 +234,7 @@ type Item(output) =
             head |> should equal (Some 50_001)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem in a very long sequence (50_000 items - fast variant)`` () =
         logStart output
 
@@ -252,7 +252,7 @@ type Item(output) =
             head |> should equal (Some 50_000)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem in a very long sequence (50_000 items - using sync Seq)`` () =
         logStart output
 
@@ -269,7 +269,7 @@ type Item(output) =
             head |> should equal (Some 50_000)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem in a very long sequence (500_000 items - fast variant)`` () =
         logStart output
 
@@ -285,7 +285,7 @@ type Item(output) =
             head |> should equal (Some 500_000)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem in a very long sequence (500_000 items - using sync Seq)`` () =
         logStart output
 
@@ -302,7 +302,7 @@ type Item(output) =
             head |> should equal (Some 500_000)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryItem gets the first item in a singleton sequence`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Iter
+namespace FSharpy.Tests
 
 open Xunit
 open FsUnit.Xunit
@@ -7,42 +7,56 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-iteri should go over all items`` () = task {
-    let tq = createDummyTaskSeq 10
-    let mutable sum = 0
-    do! tq |> TaskSeq.iteri (fun i _ -> sum <- sum + i)
-    sum |> should equal 45 // index starts at 0
-}
+type Iter(output) =
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-iter should go over all items`` () = task {
-    let tq = createDummyTaskSeq 10
-    let mutable sum = 0
-    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
-    sum |> should equal 55 // task-dummies started at 1
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-iteri should go over all items`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-iteriAsync should go over all items`` () = task {
-    let tq = createDummyTaskSeq 10
-    let mutable sum = 0
+        task {
+            let tq = createDummyTaskSeq 10
+            let mutable sum = 0
+            do! tq |> TaskSeq.iteri (fun i _ -> sum <- sum + i)
+            sum |> should equal 45 // index starts at 0
+        }
 
-    do!
-        tq
-        |> TaskSeq.iteriAsync (fun i _ -> task { sum <- sum + i })
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-iter should go over all items`` () =
+        logStart output
 
-    sum |> should equal 45 // index starts at 0
-}
+        task {
+            let tq = createDummyTaskSeq 10
+            let mutable sum = 0
+            do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+            sum |> should equal 55 // task-dummies started at 1
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-iterAsync should go over all items`` () = task {
-    let tq = createDummyTaskSeq 10
-    let mutable sum = 0
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-iteriAsync should go over all items`` () =
+        logStart output
 
-    do!
-        tq
-        |> TaskSeq.iterAsync (fun item -> task { sum <- sum + item })
+        task {
+            let tq = createDummyTaskSeq 10
+            let mutable sum = 0
 
-    sum |> should equal 55 // task-dummies started at 1
-}
+            do!
+                tq
+                |> TaskSeq.iteriAsync (fun i _ -> task { sum <- sum + i })
+
+            sum |> should equal 45 // index starts at 0
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-iterAsync should go over all items`` () =
+        logStart output
+
+        task {
+            let tq = createDummyTaskSeq 10
+            let mutable sum = 0
+
+            do!
+                tq
+                |> TaskSeq.iterAsync (fun item -> task { sum <- sum + item })
+
+            sum |> should equal 55 // task-dummies started at 1
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -7,7 +7,7 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-iteri should go over all items`` () = task {
     let tq = createDummyTaskSeq 10
     let mutable sum = 0
@@ -15,7 +15,7 @@ let ``TaskSeq-iteri should go over all items`` () = task {
     sum |> should equal 45 // index starts at 0
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-iter should go over all items`` () = task {
     let tq = createDummyTaskSeq 10
     let mutable sum = 0
@@ -23,7 +23,7 @@ let ``TaskSeq-iter should go over all items`` () = task {
     sum |> should equal 55 // task-dummies started at 1
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-iteriAsync should go over all items`` () = task {
     let tq = createDummyTaskSeq 10
     let mutable sum = 0
@@ -35,7 +35,7 @@ let ``TaskSeq-iteriAsync should go over all items`` () = task {
     sum |> should equal 45 // index starts at 0
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-iterAsync should go over all items`` () = task {
     let tq = createDummyTaskSeq 10
     let mutable sum = 0

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -9,7 +9,7 @@ open FSharpy
 
 type Iter(output) =
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-iteri should go over all items`` () =
         logStart output
 
@@ -20,7 +20,7 @@ type Iter(output) =
             sum |> should equal 45 // index starts at 0
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-iter should go over all items`` () =
         logStart output
 
@@ -31,7 +31,7 @@ type Iter(output) =
             sum |> should equal 55 // task-dummies started at 1
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-iteriAsync should go over all items`` () =
         logStart output
 
@@ -46,7 +46,7 @@ type Iter(output) =
             sum |> should equal 45 // index starts at 0
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-iterAsync should go over all items`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
@@ -8,38 +8,38 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-last throws on empty sequences`` () = task {
     fun () -> TaskSeq.empty<string> |> TaskSeq.last |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-last throws on empty sequences - variant`` () = task {
     fun () -> taskSeq { do () } |> TaskSeq.last |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryLast returns None on empty sequences`` () = task {
     let! nothing = TaskSeq.empty<string> |> TaskSeq.tryLast
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-last gets the last item in a longer sequence`` () = task {
     let! last = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50 |> TaskSeq.last
 
     last |> should equal 50
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-last gets the only item in a singleton sequence`` () = task {
     let! last = taskSeq { yield 10 } |> TaskSeq.last
     last |> should equal 10
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryLast gets the last item in a longer sequence`` () = task {
     let! last =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -49,7 +49,7 @@ let ``TaskSeq-tryLast gets the last item in a longer sequence`` () = task {
     last |> should equal (Some 50)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryLast gets the only item in a singleton sequence`` () = task {
     let! last = taskSeq { yield 10 } |> TaskSeq.tryLast
     last |> should be Some'

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Last
+namespace FSharpy.Tests
 
 open System
 open Xunit
@@ -7,51 +7,72 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+type Last(output) =
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-last throws on empty sequences`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-last throws on empty sequences`` () = task {
-    fun () -> TaskSeq.empty<string> |> TaskSeq.last |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+        task {
+            fun () -> TaskSeq.empty<string> |> TaskSeq.last |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-last throws on empty sequences - variant`` () = task {
-    fun () -> taskSeq { do () } |> TaskSeq.last |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-last throws on empty sequences - variant`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryLast returns None on empty sequences`` () = task {
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryLast
-    nothing |> should be None'
-}
+        task {
+            fun () -> taskSeq { do () } |> TaskSeq.last |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-last gets the last item in a longer sequence`` () = task {
-    let! last = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50 |> TaskSeq.last
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryLast returns None on empty sequences`` () =
+        logStart output
 
-    last |> should equal 50
-}
+        task {
+            let! nothing = TaskSeq.empty<string> |> TaskSeq.tryLast
+            nothing |> should be None'
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-last gets the only item in a singleton sequence`` () = task {
-    let! last = taskSeq { yield 10 } |> TaskSeq.last
-    last |> should equal 10
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-last gets the last item in a longer sequence`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryLast gets the last item in a longer sequence`` () = task {
-    let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryLast
+        task {
+            let! last = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50 |> TaskSeq.last
 
-    last |> should be Some'
-    last |> should equal (Some 50)
-}
+            last |> should equal 50
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-tryLast gets the only item in a singleton sequence`` () = task {
-    let! last = taskSeq { yield 10 } |> TaskSeq.tryLast
-    last |> should be Some'
-    last |> should equal (Some 10)
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-last gets the only item in a singleton sequence`` () =
+        logStart output
+
+        task {
+            let! last = taskSeq { yield 10 } |> TaskSeq.last
+            last |> should equal 10
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryLast gets the last item in a longer sequence`` () =
+        logStart output
+
+        task {
+            let! last =
+                createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+                |> TaskSeq.tryLast
+
+            last |> should be Some'
+            last |> should equal (Some 50)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-tryLast gets the only item in a singleton sequence`` () =
+        logStart output
+
+        task {
+            let! last = taskSeq { yield 10 } |> TaskSeq.tryLast
+            last |> should be Some'
+            last |> should equal (Some 10)
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
@@ -8,7 +8,7 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 type Last(output) =
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-last throws on empty sequences`` () =
         logStart output
 
@@ -17,7 +17,7 @@ type Last(output) =
             |> should throwAsyncExact typeof<ArgumentException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-last throws on empty sequences - variant`` () =
         logStart output
 
@@ -26,7 +26,7 @@ type Last(output) =
             |> should throwAsyncExact typeof<ArgumentException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryLast returns None on empty sequences`` () =
         logStart output
 
@@ -35,7 +35,7 @@ type Last(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-last gets the last item in a longer sequence`` () =
         logStart output
 
@@ -45,7 +45,7 @@ type Last(output) =
             last |> should equal 50
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-last gets the only item in a singleton sequence`` () =
         logStart output
 
@@ -54,7 +54,7 @@ type Last(output) =
             last |> should equal 10
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryLast gets the last item in a longer sequence`` () =
         logStart output
 
@@ -67,7 +67,7 @@ type Last(output) =
             last |> should equal (Some 50)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryLast gets the only item in a singleton sequence`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Map
+namespace FSharpy.Tests
 
 open Xunit
 open FsUnit.Xunit
@@ -6,29 +6,36 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+type Map(output) =
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-map maps in correct order`` () = task {
-    let! sq =
-        createDummyTaskSeq 10
-        |> TaskSeq.map (fun item -> char (item + 64))
-        |> TaskSeq.toSeqCachedAsync
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-map maps in correct order`` () =
+        logStart output
 
-    sq
-    |> Seq.map string
-    |> String.concat ""
-    |> should equal "ABCDEFGHIJ"
-}
+        task {
+            let! sq =
+                createDummyTaskSeq 10
+                |> TaskSeq.map (fun item -> char (item + 64))
+                |> TaskSeq.toSeqCachedAsync
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-mapAsync maps in correct order`` () = task {
-    let! sq =
-        createDummyTaskSeq 10
-        |> TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
-        |> TaskSeq.toSeqCachedAsync
+            sq
+            |> Seq.map string
+            |> String.concat ""
+            |> should equal "ABCDEFGHIJ"
+        }
 
-    sq
-    |> Seq.map string
-    |> String.concat ""
-    |> should equal "ABCDEFGHIJ"
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-mapAsync maps in correct order`` () =
+        logStart output
+
+        task {
+            let! sq =
+                createDummyTaskSeq 10
+                |> TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
+                |> TaskSeq.toSeqCachedAsync
+
+            sq
+            |> Seq.map string
+            |> String.concat ""
+            |> should equal "ABCDEFGHIJ"
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -8,7 +8,7 @@ open FSharpy
 
 type Map(output) =
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-map maps in correct order`` () =
         logStart output
 
@@ -24,7 +24,7 @@ type Map(output) =
             |> should equal "ABCDEFGHIJ"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-mapAsync maps in correct order`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -7,7 +7,7 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-map maps in correct order`` () = task {
     let! sq =
         createDummyTaskSeq 10
@@ -20,7 +20,7 @@ let ``TaskSeq-map maps in correct order`` () = task {
     |> should equal "ABCDEFGHIJ"
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-mapAsync maps in correct order`` () = task {
     let! sq =
         createDummyTaskSeq 10

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
@@ -13,7 +13,7 @@ type ``Conversion-From``(output) =
         do sq |> Seq.toArray |> should equal [| 0..9 |]
     }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-ofAsyncArray should succeed`` () =
         logStart output
 
@@ -21,7 +21,7 @@ type ``Conversion-From``(output) =
         |> TaskSeq.ofAsyncArray
         |> validateSequence
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-ofAsyncList should succeed`` () =
         logStart output
 
@@ -29,7 +29,7 @@ type ``Conversion-From``(output) =
         |> TaskSeq.ofAsyncList
         |> validateSequence
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-ofAsyncSeq should succeed`` () =
         logStart output
 
@@ -37,7 +37,7 @@ type ``Conversion-From``(output) =
         |> TaskSeq.ofAsyncSeq
         |> validateSequence
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-ofTaskArray should succeed`` () =
         logStart output
 
@@ -45,7 +45,7 @@ type ``Conversion-From``(output) =
         |> TaskSeq.ofTaskArray
         |> validateSequence
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-ofTaskList should succeed`` () =
         logStart output
 
@@ -53,7 +53,7 @@ type ``Conversion-From``(output) =
         |> TaskSeq.ofTaskList
         |> validateSequence
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-ofTaskSeq should succeed`` () =
         logStart output
 
@@ -61,17 +61,17 @@ type ``Conversion-From``(output) =
         |> TaskSeq.ofTaskSeq
         |> validateSequence
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-ofArray should succeed`` () =
         logStart output
         Array.init 10 id |> TaskSeq.ofArray |> validateSequence
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-ofList should succeed`` () =
         logStart output
         List.init 10 id |> TaskSeq.ofList |> validateSequence
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-ofSeq should succeed`` () =
         logStart output
         Seq.init 10 id |> TaskSeq.ofSeq |> validateSequence

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
@@ -11,47 +11,47 @@ let validateSequence sq = task {
     do sq |> Seq.toArray |> should equal [| 0..9 |]
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-ofAsyncArray should succeed`` () =
     Array.init 10 (fun x -> async { return x })
     |> TaskSeq.ofAsyncArray
     |> validateSequence
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-ofAsyncList should succeed`` () =
     List.init 10 (fun x -> async { return x })
     |> TaskSeq.ofAsyncList
     |> validateSequence
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-ofAsyncSeq should succeed`` () =
     Seq.init 10 (fun x -> async { return x })
     |> TaskSeq.ofAsyncSeq
     |> validateSequence
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-ofTaskArray should succeed`` () =
     Array.init 10 (fun x -> task { return x })
     |> TaskSeq.ofTaskArray
     |> validateSequence
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-ofTaskList should succeed`` () =
     List.init 10 (fun x -> task { return x })
     |> TaskSeq.ofTaskList
     |> validateSequence
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-ofTaskSeq should succeed`` () =
     Seq.init 10 (fun x -> task { return x })
     |> TaskSeq.ofTaskSeq
     |> validateSequence
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-ofArray should succeed`` () = Array.init 10 id |> TaskSeq.ofArray |> validateSequence
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-ofList should succeed`` () = List.init 10 id |> TaskSeq.ofList |> validateSequence
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-ofSeq should succeed`` () = Seq.init 10 id |> TaskSeq.ofSeq |> validateSequence

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.``Conversion-From``
+namespace FSharpy.Tests
 
 open Xunit
 open FsUnit.Xunit
@@ -6,52 +6,72 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
-let validateSequence sq = task {
-    let! sq = TaskSeq.toArrayAsync sq
-    do sq |> Seq.toArray |> should equal [| 0..9 |]
-}
+type ``Conversion-From``(output) =
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-ofAsyncArray should succeed`` () =
-    Array.init 10 (fun x -> async { return x })
-    |> TaskSeq.ofAsyncArray
-    |> validateSequence
+    let validateSequence sq = task {
+        let! sq = TaskSeq.toArrayAsync sq
+        do sq |> Seq.toArray |> should equal [| 0..9 |]
+    }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-ofAsyncList should succeed`` () =
-    List.init 10 (fun x -> async { return x })
-    |> TaskSeq.ofAsyncList
-    |> validateSequence
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-ofAsyncArray should succeed`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-ofAsyncSeq should succeed`` () =
-    Seq.init 10 (fun x -> async { return x })
-    |> TaskSeq.ofAsyncSeq
-    |> validateSequence
+        Array.init 10 (fun x -> async { return x })
+        |> TaskSeq.ofAsyncArray
+        |> validateSequence
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-ofTaskArray should succeed`` () =
-    Array.init 10 (fun x -> task { return x })
-    |> TaskSeq.ofTaskArray
-    |> validateSequence
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-ofAsyncList should succeed`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-ofTaskList should succeed`` () =
-    List.init 10 (fun x -> task { return x })
-    |> TaskSeq.ofTaskList
-    |> validateSequence
+        List.init 10 (fun x -> async { return x })
+        |> TaskSeq.ofAsyncList
+        |> validateSequence
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-ofTaskSeq should succeed`` () =
-    Seq.init 10 (fun x -> task { return x })
-    |> TaskSeq.ofTaskSeq
-    |> validateSequence
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-ofAsyncSeq should succeed`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-ofArray should succeed`` () = Array.init 10 id |> TaskSeq.ofArray |> validateSequence
+        Seq.init 10 (fun x -> async { return x })
+        |> TaskSeq.ofAsyncSeq
+        |> validateSequence
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-ofList should succeed`` () = List.init 10 id |> TaskSeq.ofList |> validateSequence
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-ofTaskArray should succeed`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-ofSeq should succeed`` () = Seq.init 10 id |> TaskSeq.ofSeq |> validateSequence
+        Array.init 10 (fun x -> task { return x })
+        |> TaskSeq.ofTaskArray
+        |> validateSequence
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-ofTaskList should succeed`` () =
+        logStart output
+
+        List.init 10 (fun x -> task { return x })
+        |> TaskSeq.ofTaskList
+        |> validateSequence
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-ofTaskSeq should succeed`` () =
+        logStart output
+
+        Seq.init 10 (fun x -> task { return x })
+        |> TaskSeq.ofTaskSeq
+        |> validateSequence
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-ofArray should succeed`` () =
+        logStart output
+        Array.init 10 id |> TaskSeq.ofArray |> validateSequence
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-ofList should succeed`` () =
+        logStart output
+        List.init 10 id |> TaskSeq.ofList |> validateSequence
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-ofSeq should succeed`` () =
+        logStart output
+        Seq.init 10 id |> TaskSeq.ofSeq |> validateSequence

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Pick.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Pick.Tests.fs
@@ -16,7 +16,7 @@ type Pick(output) =
     // the tryXXX versions are at the bottom half
     //
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pick on an empty sequence raises KeyNotFoundException`` () =
         logStart output
 
@@ -28,7 +28,7 @@ type Pick(output) =
             |> should throwAsyncExact typeof<KeyNotFoundException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pick on an empty sequence raises KeyNotFoundException - variant`` () =
         logStart output
 
@@ -40,7 +40,7 @@ type Pick(output) =
             |> should throwAsyncExact typeof<KeyNotFoundException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pickAsync on an empty sequence raises KeyNotFoundException`` () =
         logStart output
 
@@ -52,7 +52,7 @@ type Pick(output) =
             |> should throwAsyncExact typeof<KeyNotFoundException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pick sad path raises KeyNotFoundException`` () =
         logStart output
 
@@ -65,7 +65,7 @@ type Pick(output) =
             |> should throwAsyncExact typeof<KeyNotFoundException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pickAsync sad path raises KeyNotFoundException`` () =
         logStart output
 
@@ -78,7 +78,7 @@ type Pick(output) =
             |> should throwAsyncExact typeof<KeyNotFoundException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pick sad path raises KeyNotFoundException variant`` () =
         logStart output
 
@@ -91,7 +91,7 @@ type Pick(output) =
             |> should throwAsyncExact typeof<KeyNotFoundException>
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pickAsync sad path raises KeyNotFoundException variant`` () =
         logStart output
 
@@ -105,7 +105,7 @@ type Pick(output) =
         }
 
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pick happy path middle of seq`` () =
         logStart output
 
@@ -117,7 +117,7 @@ type Pick(output) =
             twentyFive |> should equal "foo"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pickAsync happy path middle of seq`` () =
         logStart output
 
@@ -129,7 +129,7 @@ type Pick(output) =
             twentyFive |> should equal "foo"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pick happy path first item of seq`` () =
         logStart output
 
@@ -141,7 +141,7 @@ type Pick(output) =
             first |> should equal "first1"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pickAsync happy path first item of seq`` () =
         logStart output
 
@@ -153,7 +153,7 @@ type Pick(output) =
             first |> should equal "first1"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pick happy path last item of seq`` () =
         logStart output
 
@@ -165,7 +165,7 @@ type Pick(output) =
             last |> should equal "last50"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-pickAsync happy path last item of seq`` () =
         logStart output
 
@@ -182,7 +182,7 @@ type Pick(output) =
     // TaskSeq.tryPickAsync
     //
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryPick on an empty sequence returns None`` () =
         logStart output
 
@@ -194,7 +194,7 @@ type Pick(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryPickAsync on an empty sequence returns None`` () =
         logStart output
 
@@ -206,7 +206,7 @@ type Pick(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryPick sad path returns None`` () =
         logStart output
 
@@ -218,7 +218,7 @@ type Pick(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryPickAsync sad path return None`` () =
         logStart output
 
@@ -230,7 +230,7 @@ type Pick(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryPick sad path returns None variant`` () =
         logStart output
 
@@ -242,7 +242,7 @@ type Pick(output) =
             nothing |> should be None'
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryPickAsync sad path return None - variant`` () =
         logStart output
 
@@ -255,7 +255,7 @@ type Pick(output) =
         }
 
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryPick happy path middle of seq`` () =
         logStart output
 
@@ -268,7 +268,7 @@ type Pick(output) =
             twentyFive |> should equal (Some "foo25")
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryPickAsync happy path middle of seq`` () =
         logStart output
 
@@ -281,7 +281,7 @@ type Pick(output) =
             twentyFive |> should equal (Some "foo25")
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryPick happy path first item of seq`` () =
         logStart output
 
@@ -294,7 +294,7 @@ type Pick(output) =
             first |> should equal (Some "foo1")
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryPickAsync happy path first item of seq`` () =
         logStart output
 
@@ -307,7 +307,7 @@ type Pick(output) =
             first |> should equal (Some "foo1")
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryPick happy path last item of seq`` () =
         logStart output
 
@@ -320,7 +320,7 @@ type Pick(output) =
             last |> should equal (Some "foo50")
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-tryPickAsync happy path last item of seq`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Pick.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Pick.Tests.fs
@@ -15,7 +15,7 @@ open FSharpy
 // the tryXXX versions are at the bottom half
 //
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pick on an empty sequence raises KeyNotFoundException`` () = task {
     fun () ->
         TaskSeq.empty
@@ -24,7 +24,7 @@ let ``TaskSeq-pick on an empty sequence raises KeyNotFoundException`` () = task 
     |> should throwAsyncExact typeof<KeyNotFoundException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pick on an empty sequence raises KeyNotFoundException - variant`` () = task {
     fun () ->
         taskSeq { do () }
@@ -33,7 +33,7 @@ let ``TaskSeq-pick on an empty sequence raises KeyNotFoundException - variant`` 
     |> should throwAsyncExact typeof<KeyNotFoundException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pickAsync on an empty sequence raises KeyNotFoundException`` () = task {
     fun () ->
         TaskSeq.empty
@@ -42,7 +42,7 @@ let ``TaskSeq-pickAsync on an empty sequence raises KeyNotFoundException`` () = 
     |> should throwAsyncExact typeof<KeyNotFoundException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pick sad path raises KeyNotFoundException`` () = task {
     fun () ->
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -52,7 +52,7 @@ let ``TaskSeq-pick sad path raises KeyNotFoundException`` () = task {
     |> should throwAsyncExact typeof<KeyNotFoundException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pickAsync sad path raises KeyNotFoundException`` () = task {
     fun () ->
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -62,7 +62,7 @@ let ``TaskSeq-pickAsync sad path raises KeyNotFoundException`` () = task {
     |> should throwAsyncExact typeof<KeyNotFoundException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pick sad path raises KeyNotFoundException variant`` () = task {
     fun () ->
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -72,7 +72,7 @@ let ``TaskSeq-pick sad path raises KeyNotFoundException variant`` () = task {
     |> should throwAsyncExact typeof<KeyNotFoundException>
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pickAsync sad path raises KeyNotFoundException variant`` () = task {
     fun () ->
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -83,7 +83,7 @@ let ``TaskSeq-pickAsync sad path raises KeyNotFoundException variant`` () = task
 }
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pick happy path middle of seq`` () = task {
     let! twentyFive =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -92,7 +92,7 @@ let ``TaskSeq-pick happy path middle of seq`` () = task {
     twentyFive |> should equal "foo"
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pickAsync happy path middle of seq`` () = task {
     let! twentyFive =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -101,7 +101,7 @@ let ``TaskSeq-pickAsync happy path middle of seq`` () = task {
     twentyFive |> should equal "foo"
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pick happy path first item of seq`` () = task {
     let! first =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -110,7 +110,7 @@ let ``TaskSeq-pick happy path first item of seq`` () = task {
     first |> should equal "first1"
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pickAsync happy path first item of seq`` () = task {
     let! first =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -119,7 +119,7 @@ let ``TaskSeq-pickAsync happy path first item of seq`` () = task {
     first |> should equal "first1"
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pick happy path last item of seq`` () = task {
     let! last =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -128,7 +128,7 @@ let ``TaskSeq-pick happy path last item of seq`` () = task {
     last |> should equal "last50"
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-pickAsync happy path last item of seq`` () = task {
     let! last =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -142,7 +142,7 @@ let ``TaskSeq-pickAsync happy path last item of seq`` () = task {
 // TaskSeq.tryPickAsync
 //
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryPick on an empty sequence returns None`` () = task {
     let! nothing =
         TaskSeq.empty
@@ -151,7 +151,7 @@ let ``TaskSeq-tryPick on an empty sequence returns None`` () = task {
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryPickAsync on an empty sequence returns None`` () = task {
     let! nothing =
         TaskSeq.empty
@@ -160,7 +160,7 @@ let ``TaskSeq-tryPickAsync on an empty sequence returns None`` () = task {
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryPick sad path returns None`` () = task {
     let! nothing =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -169,7 +169,7 @@ let ``TaskSeq-tryPick sad path returns None`` () = task {
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryPickAsync sad path return None`` () = task {
     let! nothing =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -178,7 +178,7 @@ let ``TaskSeq-tryPickAsync sad path return None`` () = task {
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryPick sad path returns None variant`` () = task {
     let! nothing =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -187,7 +187,7 @@ let ``TaskSeq-tryPick sad path returns None variant`` () = task {
     nothing |> should be None'
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryPickAsync sad path return None - variant`` () = task {
     let! nothing =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -197,7 +197,7 @@ let ``TaskSeq-tryPickAsync sad path return None - variant`` () = task {
 }
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryPick happy path middle of seq`` () = task {
     let! twentyFive =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -207,7 +207,7 @@ let ``TaskSeq-tryPick happy path middle of seq`` () = task {
     twentyFive |> should equal (Some "foo25")
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryPickAsync happy path middle of seq`` () = task {
     let! twentyFive =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -217,7 +217,7 @@ let ``TaskSeq-tryPickAsync happy path middle of seq`` () = task {
     twentyFive |> should equal (Some "foo25")
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryPick happy path first item of seq`` () = task {
     let! first =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -227,7 +227,7 @@ let ``TaskSeq-tryPick happy path first item of seq`` () = task {
     first |> should equal (Some "foo1")
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryPickAsync happy path first item of seq`` () = task {
     let! first =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -237,7 +237,7 @@ let ``TaskSeq-tryPickAsync happy path first item of seq`` () = task {
     first |> should equal (Some "foo1")
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryPick happy path last item of seq`` () = task {
     let! last =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
@@ -247,7 +247,7 @@ let ``TaskSeq-tryPick happy path last item of seq`` () = task {
     last |> should equal (Some "foo50")
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-tryPickAsync happy path last item of seq`` () = task {
     let! last =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.PocTests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.PocTests.fs
@@ -15,77 +15,92 @@ open FSharpy
 /////////////////////////////////////////////////////////////////////////////
 
 
-module ``PoC's for seq of tasks`` =
+type ``PoC's for seq of tasks``(output) =
 
     [<Fact(Timeout = 10_000)>]
-    let ``Good: Show joining tasks with continuation is good`` () = task {
-        // acts like a fold
-        let! results = createAndJoinMultipleTasks 10 joinWithContinuation
-        results |> should equal 10
-    }
+    let ``Good: Show joining tasks with continuation is good`` () =
+        logStart output
 
-    [<Fact(Timeout = 10_000)>]
-    let ``Good: Show that joining tasks with 'bind' in task CE is good`` () = task {
-        let! tasks = createAndJoinMultipleTasks 10 joinIdentityDelayed
-
-        let tasks = tasks |> Array.ofList
-        let len = Array.length tasks
-        let results = Array.zeroCreate len
-
-        for i in 0 .. len - 1 do
-            // this uses Task.bind under the hood, which ensures order-of-execution and wait-for-previous
-            let! item = tasks[i]() // only now are we delay-executing the task in the array
-            results[i] <- item
-
-        results |> should equal <| Array.init len ((+) 1)
-    }
-
-    [<Fact(Timeout = 10_000)>]
-    let ``Good: Show that joining tasks with 'taskSeq' is good`` () = task {
-        let! tasks = createAndJoinMultipleTasks 10 joinIdentityDelayed
-
-        let asAsyncSeq = taskSeq {
-            for task in tasks do
-                // cannot use `yield!` here, as `taskSeq` expects it to return a seq
-                let! x = task ()
-                yield x
+        task {
+            // acts like a fold
+            let! results = createAndJoinMultipleTasks 10 joinWithContinuation
+            results |> should equal 10
         }
 
-        let! results = asAsyncSeq |> TaskSeq.toArrayAsync
+    [<Fact(Timeout = 10_000)>]
+    let ``Good: Show that joining tasks with 'bind' in task CE is good`` () =
+        logStart output
 
-        results |> should equal
-        <| Array.init (Array.length results) ((+) 1)
-    }
+        task {
+            let! tasks = createAndJoinMultipleTasks 10 joinIdentityDelayed
+
+            let tasks = tasks |> Array.ofList
+            let len = Array.length tasks
+            let results = Array.zeroCreate len
+
+            for i in 0 .. len - 1 do
+                // this uses Task.bind under the hood, which ensures order-of-execution and wait-for-previous
+                let! item = tasks[i]() // only now are we delay-executing the task in the array
+                results[i] <- item
+
+            results |> should equal <| Array.init len ((+) 1)
+        }
 
     [<Fact(Timeout = 10_000)>]
-    let ``Bad: Show that joining tasks with 'traverseTaskResult' can be bad`` () = task {
-        let! taskList = createAndJoinMultipleTasks 10 joinIdentityHotStarted
+    let ``Good: Show that joining tasks with 'taskSeq' is good`` () =
+        logStart output
 
-        // since tasks are hot-started, by this time they are already *all* running
-        let! results =
-            taskList
-            |> List.map (Task.map Result<int, string>.Ok)
-            |> List.traverseTaskResultA id
+        task {
+            let! tasks = createAndJoinMultipleTasks 10 joinIdentityDelayed
 
-        match results with
-        | Ok results ->
+            let asAsyncSeq = taskSeq {
+                for task in tasks do
+                    // cannot use `yield!` here, as `taskSeq` expects it to return a seq
+                    let! x = task ()
+                    yield x
+            }
+
+            let! results = asAsyncSeq |> TaskSeq.toArrayAsync
+
+            results |> should equal
+            <| Array.init (Array.length results) ((+) 1)
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``Bad: Show that joining tasks with 'traverseTaskResult' can be bad`` () =
+        logStart output
+
+        task {
+            let! taskList = createAndJoinMultipleTasks 10 joinIdentityHotStarted
+
+            // since tasks are hot-started, by this time they are already *all* running
+            let! results =
+                taskList
+                |> List.map (Task.map Result<int, string>.Ok)
+                |> List.traverseTaskResultA id
+
+            match results with
+            | Ok results ->
+                results |> should not'
+                <| equal (List.init (List.length results) ((+) 1))
+            | Error err -> failwith $"Impossible: {err}"
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``Bad: Show that joining tasks as a list of tasks can be bad`` () =
+        logStart output
+
+        task {
+            let! taskList = createAndJoinMultipleTasks 10 joinIdentityHotStarted
+
+            // since tasks are hot-started, by this time they are already *all* running
+            let tasks = taskList |> Array.ofList
+            let results = Array.zeroCreate 10
+
+            for i in 0..9 do
+                let! item = tasks[i]
+                results[i] <- item
+
             results |> should not'
-            <| equal (List.init (List.length results) ((+) 1))
-        | Error err -> failwith $"Impossible: {err}"
-    }
-
-    [<Fact(Timeout = 10_000)>]
-    let ``Bad: Show that joining tasks as a list of tasks can be bad`` () = task {
-        let! taskList = createAndJoinMultipleTasks 10 joinIdentityHotStarted
-
-        // since tasks are hot-started, by this time they are already *all* running
-        let tasks = taskList |> Array.ofList
-        let results = Array.zeroCreate 10
-
-        for i in 0..9 do
-            let! item = tasks[i]
-            results[i] <- item
-
-        results |> should not'
-        <| equal (Array.init (Array.length results) ((+) 1))
-    }
+            <| equal (Array.init (Array.length results) ((+) 1))
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.PocTests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.PocTests.fs
@@ -17,14 +17,14 @@ open FSharpy
 
 module ``PoC's for seq of tasks`` =
 
-    [<Fact>]
+    [<Fact(Timeout = 10_000)>]
     let ``Good: Show joining tasks with continuation is good`` () = task {
         // acts like a fold
         let! results = createAndJoinMultipleTasks 10 joinWithContinuation
         results |> should equal 10
     }
 
-    [<Fact>]
+    [<Fact(Timeout = 10_000)>]
     let ``Good: Show that joining tasks with 'bind' in task CE is good`` () = task {
         let! tasks = createAndJoinMultipleTasks 10 joinIdentityDelayed
 
@@ -40,7 +40,7 @@ module ``PoC's for seq of tasks`` =
         results |> should equal <| Array.init len ((+) 1)
     }
 
-    [<Fact>]
+    [<Fact(Timeout = 10_000)>]
     let ``Good: Show that joining tasks with 'taskSeq' is good`` () = task {
         let! tasks = createAndJoinMultipleTasks 10 joinIdentityDelayed
 
@@ -57,7 +57,7 @@ module ``PoC's for seq of tasks`` =
         <| Array.init (Array.length results) ((+) 1)
     }
 
-    [<Fact>]
+    [<Fact(Timeout = 10_000)>]
     let ``Bad: Show that joining tasks with 'traverseTaskResult' can be bad`` () = task {
         let! taskList = createAndJoinMultipleTasks 10 joinIdentityHotStarted
 
@@ -74,7 +74,7 @@ module ``PoC's for seq of tasks`` =
         | Error err -> failwith $"Impossible: {err}"
     }
 
-    [<Fact>]
+    [<Fact(Timeout = 10_000)>]
     let ``Bad: Show that joining tasks as a list of tasks can be bad`` () = task {
         let! taskList = createAndJoinMultipleTasks 10 joinIdentityHotStarted
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.PocTests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.PocTests.fs
@@ -17,7 +17,7 @@ open FSharpy
 
 type ``PoC's for seq of tasks``(output) =
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``Good: Show joining tasks with continuation is good`` () =
         logStart output
 
@@ -27,7 +27,7 @@ type ``PoC's for seq of tasks``(output) =
             results |> should equal 10
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``Good: Show that joining tasks with 'bind' in task CE is good`` () =
         logStart output
 
@@ -46,7 +46,7 @@ type ``PoC's for seq of tasks``(output) =
             results |> should equal <| Array.init len ((+) 1)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``Good: Show that joining tasks with 'taskSeq' is good`` () =
         logStart output
 
@@ -66,7 +66,7 @@ type ``PoC's for seq of tasks``(output) =
             <| Array.init (Array.length results) ((+) 1)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``Bad: Show that joining tasks with 'traverseTaskResult' can be bad`` () =
         logStart output
 
@@ -86,7 +86,7 @@ type ``PoC's for seq of tasks``(output) =
             | Error err -> failwith $"Impossible: {err}"
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``Bad: Show that joining tasks as a list of tasks can be bad`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.``taskSeq Computation Expression``
+namespace FSharpy.Tests
 
 open Xunit
 open FsUnit.Xunit
@@ -8,82 +8,86 @@ open FSharpy
 open System.Threading.Tasks
 open System.Diagnostics
 
+type ``taskSeq Computation Expression``(output) =
 
-[<Fact(Timeout = 10_000)>]
-let ``CE taskSeq with several yield!`` () = task {
-    let tskSeq = taskSeq {
-        yield! createDummyTaskSeq 10
-        yield! createDummyTaskSeq 5
-        yield! createDummyTaskSeq 10
-        yield! createDummyTaskSeq 5
-    }
+    [<Fact(Timeout = 10_000)>]
+    let ``CE taskSeq with several yield!`` () =
+        logStart output
 
-    let! data = tskSeq |> TaskSeq.toListAsync
+        task {
+            let tskSeq = taskSeq {
+                yield! createDummyTaskSeq 10
+                yield! createDummyTaskSeq 5
+                yield! createDummyTaskSeq 10
+                yield! createDummyTaskSeq 5
+            }
 
-    data
-    |> should equal (List.concat [ [ 1..10 ]; [ 1..5 ]; [ 1..10 ]; [ 1..5 ] ])
-}
+            let! data = tskSeq |> TaskSeq.toListAsync
 
-[<Fact(Timeout = 10_000)>]
-let ``CE taskSeq with nested yield!`` () = task {
-    let control = seq {
-        yield! [ 1..10 ]
+            data
+            |> should equal (List.concat [ [ 1..10 ]; [ 1..5 ]; [ 1..10 ]; [ 1..5 ] ])
+        }
 
-        for i in 0..9 do
-            yield! [ 1..2 ]
+    [<Fact(Timeout = 10_000)>]
+    let ``CE taskSeq with nested yield!`` () =
+        logStart output
 
-            for i in 0..2 do
-                yield! seq { yield 42 }
+        task {
+            let control = seq {
+                yield! [ 1..10 ]
 
-                for i in 100..102 do
-                    yield! seq { yield! seq { yield i } }
-    }
+                for i in 0..9 do
+                    yield! [ 1..2 ]
 
-    let tskSeq = taskSeq {
-        yield! createDummyTaskSeq 10
+                    for i in 0..2 do
+                        yield! seq { yield 42 }
 
-        for i in 0..9 do
-            yield! createDummyTaskSeq 2
+                        for i in 100..102 do
+                            yield! seq { yield! seq { yield i } }
+            }
 
-            for i in 0..2 do
-                yield! taskSeq { yield 42 }
+            let tskSeq = taskSeq {
+                yield! createDummyTaskSeq 10
 
-                for i in 100..102 do
-                    yield! taskSeq { yield! taskSeq { yield i } }
-    }
+                for i in 0..9 do
+                    yield! createDummyTaskSeq 2
 
-    let! data = tskSeq |> TaskSeq.toListAsync
+                    for i in 0..2 do
+                        yield! taskSeq { yield 42 }
 
-    data |> should equal (List.ofSeq control)
-    data |> should haveLength 150
-}
+                        for i in 100..102 do
+                            yield! taskSeq { yield! taskSeq { yield i } }
+            }
 
-[<Fact(Timeout = 10_000)>]
-let ``CE taskSeq with nested deeply yield! perf test 8521 nested tasks`` () = task {
-    let control = seq {
-        yield! [ 1..10 ]
+            let! data = tskSeq |> TaskSeq.toListAsync
 
-        // original:
-        yield! Seq.concat <| Seq.init 4251 (fun _ -> [ 1; 2 ])
-    //yield! Seq.concat <| Seq.init 120 (fun _ -> [ 1; 2 ])
-    }
+            data |> should equal (List.ofSeq control)
+            data |> should haveLength 150
+        }
 
-    let createTasks = createDummyTaskSeqWith 1L<µs> 10L<µs>
-    // FIXME: it appears that deeply nesting adds to performance degradation, need to benchmark/profile this
-    // probably cause: since this is *fast* with DirectTask, the reason is likely the way the Task.Delay causes
-    // *many* subtasks to be delayed, resulting in exponential delay. Reason: max accuracy of Delay is about 15ms (!)
+    [<Fact(Timeout = 10_000)>]
+    let ``CE taskSeq with nested deeply yield! perf test 8521 nested tasks`` () =
+        logStart output
 
-    // RESOLUTION: seems to have been caused by erratic Task.Delay which has only a 15ms resolution
-    let tskSeq = taskSeq {
-        yield! createTasks 10
+        task {
+            let control = seq {
+                yield! [ 1..10 ]
 
-        // nestings amount to 8512 sequences of [1;2]
-        for i in 0..2 do
-            yield! createTasks 2
+                // original:
+                yield! Seq.concat <| Seq.init 4251 (fun _ -> [ 1; 2 ])
+            //yield! Seq.concat <| Seq.init 120 (fun _ -> [ 1; 2 ])
+            }
 
-            for i in 0..2 do
-                yield! createTasks 2
+            let createTasks = createDummyTaskSeqWith 1L<µs> 10L<µs>
+            // FIXME: it appears that deeply nesting adds to performance degradation, need to benchmark/profile this
+            // probably cause: since this is *fast* with DirectTask, the reason is likely the way the Task.Delay causes
+            // *many* subtasks to be delayed, resulting in exponential delay. Reason: max accuracy of Delay is about 15ms (!)
 
+            // RESOLUTION: seems to have been caused by erratic Task.Delay which has only a 15ms resolution
+            let tskSeq = taskSeq {
+                yield! createTasks 10
+
+                // nestings amount to 8512 sequences of [1;2]
                 for i in 0..2 do
                     yield! createTasks 2
 
@@ -96,123 +100,153 @@ let ``CE taskSeq with nested deeply yield! perf test 8521 nested tasks`` () = ta
                             for i in 0..2 do
                                 yield! createTasks 2
 
-                        for i in 0..2 do
-                            yield! createTasks 2
+                                for i in 0..2 do
+                                    yield! createTasks 2
 
-                            for i in 0..2 do
-                                yield! createTasks 2
+                                    for i in 0..2 do
+                                        yield! createTasks 2
 
                                 for i in 0..2 do
                                     yield! createTasks 2
 
-                        yield! TaskSeq.empty
-    }
+                                    for i in 0..2 do
+                                        yield! createTasks 2
 
-    let! data = tskSeq |> TaskSeq.toListAsync
-    data |> List.length |> should equal 8512
-    data |> should equal (List.ofSeq control)
-}
+                                        for i in 0..2 do
+                                            yield! createTasks 2
 
-[<Fact(Timeout = 10_000)>]
-let ``CE taskSeq with several return!`` () = task {
-    // TODO: should we even support this? Traditional 'seq' doesn't.
-    let tskSeq = taskSeq {
-        return! createDummyTaskSeq 10
-        return! createDummyTaskSeq 5
-    }
+                                yield! TaskSeq.empty
+            }
 
-    let! data = tskSeq |> TaskSeq.toListAsync
+            let! data = tskSeq |> TaskSeq.toListAsync
+            data |> List.length |> should equal 8512
+            data |> should equal (List.ofSeq control)
+        }
 
-    // FIXME!!! This behavior is *probably* not correct
-    data |> should equal [ 1..10 ]
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``CE taskSeq with several return!`` () =
+        logStart output
+
+        task {
+            // TODO: should we even support this? Traditional 'seq' doesn't.
+            let tskSeq = taskSeq {
+                return! createDummyTaskSeq 10
+                return! createDummyTaskSeq 5
+            }
+
+            let! data = tskSeq |> TaskSeq.toListAsync
+
+            // FIXME!!! This behavior is *probably* not correct
+            data |> should equal [ 1..10 ]
+        }
 
 
-[<Fact(Timeout = 10_000)>]
-let ``CE taskSeq with mixing yield! and yield`` () = task {
-    let tskSeq = taskSeq {
-        yield! createDummyTaskSeq 10
-        yield 42
-        yield! createDummyTaskSeq 5
-        yield 42
-        yield! createDummyTaskSeq 10
-        yield 42
-        yield! createDummyTaskSeq 5
-    }
+    [<Fact(Timeout = 10_000)>]
+    let ``CE taskSeq with mixing yield! and yield`` () =
+        logStart output
 
-    let! data = tskSeq |> TaskSeq.toListAsync
+        task {
+            let tskSeq = taskSeq {
+                yield! createDummyTaskSeq 10
+                yield 42
+                yield! createDummyTaskSeq 5
+                yield 42
+                yield! createDummyTaskSeq 10
+                yield 42
+                yield! createDummyTaskSeq 5
+            }
 
-    data
-    |> should equal (List.concat [ [ 1..10 ]; [ 42 ]; [ 1..5 ]; [ 42 ]; [ 1..10 ]; [ 42 ]; [ 1..5 ] ])
-}
+            let! data = tskSeq |> TaskSeq.toListAsync
 
-[<Fact(Timeout = 10_000)>]
-let ``CE taskSeq: 1000 TaskDelay-delayed tasks using yield!`` () = task {
-    // Smoke performance test
-    // Runs in slightly over half a second (average of spin-wait, plus small overhead)
-    // should generally be about as fast as `task`, see below for equivalent test.
-    let tskSeq = taskSeq { yield! createDummyTaskSeqWith 50L<µs> 1000L<µs> 1000 }
-    let! data = tskSeq |> TaskSeq.toListAsync
-    data |> should equal [ 1..1000 ]
-}
+            data
+            |> should equal (List.concat [ [ 1..10 ]; [ 42 ]; [ 1..5 ]; [ 42 ]; [ 1..10 ]; [ 42 ]; [ 1..5 ] ])
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``CE taskSeq: 1000 sync-running tasks using yield!`` () = task {
-    // Smoke performance test
-    // Runs in a few 10's of ms, because of absense of Task.Delay
-    // should generally be about as fast as `task`, see below
-    let tskSeq = taskSeq { yield! createDummyDirectTaskSeq 1000 }
-    let! data = tskSeq |> TaskSeq.toListAsync
-    data |> should equal [ 1..1000 ]
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``CE taskSeq: 1000 TaskDelay-delayed tasks using yield!`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``CE taskSeq: 5000 sync-running tasks using yield!`` () = task {
-    // Smoke performance test
-    // Compare with task-ce test below. Uses a no-delay hot-started sequence of tasks.
-    let tskSeq = taskSeq { yield! createDummyDirectTaskSeq 5000 }
-    let! data = tskSeq |> TaskSeq.toListAsync
-    data |> should equal [ 1..5000 ]
-}
+        task {
+            // Smoke performance test
+            // Runs in slightly over half a second (average of spin-wait, plus small overhead)
+            // should generally be about as fast as `task`, see below for equivalent test.
+            let tskSeq = taskSeq { yield! createDummyTaskSeqWith 50L<µs> 1000L<µs> 1000 }
+            let! data = tskSeq |> TaskSeq.toListAsync
+            data |> should equal [ 1..1000 ]
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``CE task: 1000 TaskDelay-delayed tasks using for-loop`` () = task {
-    // Uses SpinWait for effective task-delaying
-    // for smoke-test comparison with taskSeq
-    let tasks = DummyTaskFactory(50L<µs>, 1000L<µs>).CreateDelayedTasks 1000
-    let mutable i = 0
+    [<Fact(Timeout = 10_000)>]
+    let ``CE taskSeq: 1000 sync-running tasks using yield!`` () =
+        logStart output
 
-    for t in tasks do
-        i <- i + 1
-        do! t () |> Task.ignore
+        task {
+            // Smoke performance test
+            // Runs in a few 10's of ms, because of absense of Task.Delay
+            // should generally be about as fast as `task`, see below
+            let tskSeq = taskSeq { yield! createDummyDirectTaskSeq 1000 }
+            let! data = tskSeq |> TaskSeq.toListAsync
+            data |> should equal [ 1..1000 ]
+        }
 
-    i |> should equal 1000
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``CE taskSeq: 5000 sync-running tasks using yield!`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``CE task: 1000 list of sync-running tasks using for-loop`` () = task {
-    // runs in a few 10's of ms, because of absense of Task.Delay
-    // for smoke-test comparison with taskSeq
-    let tasks = DummyTaskFactory().CreateDirectTasks 1000
-    let mutable i = 0
+        task {
+            // Smoke performance test
+            // Compare with task-ce test below. Uses a no-delay hot-started sequence of tasks.
+            let tskSeq = taskSeq { yield! createDummyDirectTaskSeq 5000 }
+            let! data = tskSeq |> TaskSeq.toListAsync
+            data |> should equal [ 1..5000 ]
+        }
 
-    for t in tasks do
-        i <- i + 1
-        do! t () |> Task.ignore
+    [<Fact(Timeout = 10_000)>]
+    let ``CE task: 1000 TaskDelay-delayed tasks using for-loop`` () =
+        logStart output
 
-    i |> should equal 1000
-}
+        task {
+            // Uses SpinWait for effective task-delaying
+            // for smoke-test comparison with taskSeq
+            let tasks = DummyTaskFactory(50L<µs>, 1000L<µs>).CreateDelayedTasks 1000
+            let mutable i = 0
 
-[<Fact(Timeout = 10_000)>]
-let ``CE task: 5000 list of sync-running tasks using for-loop`` () = task {
-    // runs in a few 100's of ms, because of absense of Task.Delay
-    // for smoke-test comparison with taskSeq
-    let tasks = DummyTaskFactory().CreateDirectTasks 5000
-    let mutable i = 0
+            for t in tasks do
+                i <- i + 1
+                do! t () |> Task.ignore
 
-    for t in tasks do
-        i <- i + 1
-        do! t () |> Task.ignore
+            i |> should equal 1000
+        }
 
-    i |> should equal 5000
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``CE task: 1000 list of sync-running tasks using for-loop`` () =
+        logStart output
+
+        task {
+            // runs in a few 10's of ms, because of absense of Task.Delay
+            // for smoke-test comparison with taskSeq
+            let tasks = DummyTaskFactory().CreateDirectTasks 1000
+            let mutable i = 0
+
+            for t in tasks do
+                i <- i + 1
+                do! t () |> Task.ignore
+
+            i |> should equal 1000
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``CE task: 5000 list of sync-running tasks using for-loop`` () =
+        logStart output
+
+        task {
+            // runs in a few 100's of ms, because of absense of Task.Delay
+            // for smoke-test comparison with taskSeq
+            let tasks = DummyTaskFactory().CreateDirectTasks 5000
+            let mutable i = 0
+
+            for t in tasks do
+                i <- i + 1
+                do! t () |> Task.ignore
+
+            i |> should equal 5000
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
@@ -1,4 +1,4 @@
-﻿module FSharpy.Tests.``taskSeq Computation Expression``
+module FSharpy.Tests.``taskSeq Computation Expression``
 
 open Xunit
 open FsUnit.Xunit
@@ -9,7 +9,7 @@ open System.Threading.Tasks
 open System.Diagnostics
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``CE taskSeq with several yield!`` () = task {
     let tskSeq = taskSeq {
         yield! createDummyTaskSeq 10
@@ -24,7 +24,7 @@ let ``CE taskSeq with several yield!`` () = task {
     |> should equal (List.concat [ [ 1..10 ]; [ 1..5 ]; [ 1..10 ]; [ 1..5 ] ])
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``CE taskSeq with nested yield!`` () = task {
     let control = seq {
         yield! [ 1..10 ]
@@ -58,7 +58,7 @@ let ``CE taskSeq with nested yield!`` () = task {
     data |> should haveLength 150
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``CE taskSeq with nested deeply yield! perf test 8521 nested tasks`` () = task {
     let control = seq {
         yield! [ 1..10 ]
@@ -113,7 +113,7 @@ let ``CE taskSeq with nested deeply yield! perf test 8521 nested tasks`` () = ta
     data |> should equal (List.ofSeq control)
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``CE taskSeq with several return!`` () = task {
     // TODO: should we even support this? Traditional 'seq' doesn't.
     let tskSeq = taskSeq {
@@ -128,7 +128,7 @@ let ``CE taskSeq with several return!`` () = task {
 }
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``CE taskSeq with mixing yield! and yield`` () = task {
     let tskSeq = taskSeq {
         yield! createDummyTaskSeq 10
@@ -146,7 +146,7 @@ let ``CE taskSeq with mixing yield! and yield`` () = task {
     |> should equal (List.concat [ [ 1..10 ]; [ 42 ]; [ 1..5 ]; [ 42 ]; [ 1..10 ]; [ 42 ]; [ 1..5 ] ])
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``CE taskSeq: 1000 TaskDelay-delayed tasks using yield!`` () = task {
     // Smoke performance test
     // Runs in slightly over half a second (average of spin-wait, plus small overhead)
@@ -156,7 +156,7 @@ let ``CE taskSeq: 1000 TaskDelay-delayed tasks using yield!`` () = task {
     data |> should equal [ 1..1000 ]
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``CE taskSeq: 1000 sync-running tasks using yield!`` () = task {
     // Smoke performance test
     // Runs in a few 10's of ms, because of absense of Task.Delay
@@ -166,7 +166,7 @@ let ``CE taskSeq: 1000 sync-running tasks using yield!`` () = task {
     data |> should equal [ 1..1000 ]
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``CE taskSeq: 5000 sync-running tasks using yield!`` () = task {
     // Smoke performance test
     // Compare with task-ce test below. Uses a no-delay hot-started sequence of tasks.
@@ -175,7 +175,7 @@ let ``CE taskSeq: 5000 sync-running tasks using yield!`` () = task {
     data |> should equal [ 1..5000 ]
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``CE task: 1000 TaskDelay-delayed tasks using for-loop`` () = task {
     // Uses SpinWait for effective task-delaying
     // for smoke-test comparison with taskSeq
@@ -189,7 +189,7 @@ let ``CE task: 1000 TaskDelay-delayed tasks using for-loop`` () = task {
     i |> should equal 1000
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``CE task: 1000 list of sync-running tasks using for-loop`` () = task {
     // runs in a few 10's of ms, because of absense of Task.Delay
     // for smoke-test comparison with taskSeq
@@ -203,7 +203,7 @@ let ``CE task: 1000 list of sync-running tasks using for-loop`` () = task {
     i |> should equal 1000
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``CE task: 5000 list of sync-running tasks using for-loop`` () = task {
     // runs in a few 100's of ms, because of absense of Task.Delay
     // for smoke-test comparison with taskSeq

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
@@ -10,7 +10,7 @@ open System.Diagnostics
 
 type ``taskSeq Computation Expression``(output) =
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``CE taskSeq with several yield!`` () =
         logStart output
 
@@ -28,7 +28,7 @@ type ``taskSeq Computation Expression``(output) =
             |> should equal (List.concat [ [ 1..10 ]; [ 1..5 ]; [ 1..10 ]; [ 1..5 ] ])
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``CE taskSeq with nested yield!`` () =
         logStart output
 
@@ -65,7 +65,7 @@ type ``taskSeq Computation Expression``(output) =
             data |> should haveLength 150
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``CE taskSeq with nested deeply yield! perf test 8521 nested tasks`` () =
         logStart output
 
@@ -123,7 +123,7 @@ type ``taskSeq Computation Expression``(output) =
             data |> should equal (List.ofSeq control)
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``CE taskSeq with several return!`` () =
         logStart output
 
@@ -141,7 +141,7 @@ type ``taskSeq Computation Expression``(output) =
         }
 
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``CE taskSeq with mixing yield! and yield`` () =
         logStart output
 
@@ -162,7 +162,7 @@ type ``taskSeq Computation Expression``(output) =
             |> should equal (List.concat [ [ 1..10 ]; [ 42 ]; [ 1..5 ]; [ 42 ]; [ 1..10 ]; [ 42 ]; [ 1..5 ] ])
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``CE taskSeq: 1000 TaskDelay-delayed tasks using yield!`` () =
         logStart output
 
@@ -175,7 +175,7 @@ type ``taskSeq Computation Expression``(output) =
             data |> should equal [ 1..1000 ]
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``CE taskSeq: 1000 sync-running tasks using yield!`` () =
         logStart output
 
@@ -188,7 +188,7 @@ type ``taskSeq Computation Expression``(output) =
             data |> should equal [ 1..1000 ]
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``CE taskSeq: 5000 sync-running tasks using yield!`` () =
         logStart output
 
@@ -200,7 +200,7 @@ type ``taskSeq Computation Expression``(output) =
             data |> should equal [ 1..5000 ]
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``CE task: 1000 TaskDelay-delayed tasks using for-loop`` () =
         logStart output
 
@@ -217,7 +217,7 @@ type ``taskSeq Computation Expression``(output) =
             i |> should equal 1000
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``CE task: 1000 list of sync-running tasks using for-loop`` () =
         logStart output
 
@@ -234,7 +234,7 @@ type ``taskSeq Computation Expression``(output) =
             i |> should equal 1000
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``CE task: 5000 list of sync-running tasks using for-loop`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.Other.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.Other.fs
@@ -7,20 +7,20 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-empty returns an empty sequence`` () = task {
     let! sq = TaskSeq.empty<string> |> TaskSeq.toSeqCachedAsync
     Seq.isEmpty sq |> should be True
     Seq.length sq |> should equal 0
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-isEmpty returns true for empty`` () = task {
     let! isEmpty = TaskSeq.empty<string> |> TaskSeq.isEmpty
     isEmpty |> should be True
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-isEmpty returns false for non-empty`` () = task {
     let! isEmpty = taskSeq { yield 42 } |> TaskSeq.isEmpty
     isEmpty |> should be False

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.Other.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.Other.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.``Other functions``
+namespace FSharpy.Tests
 
 open Xunit
 open FsUnit.Xunit
@@ -6,22 +6,32 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+type ``Other functions``(output) =
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-empty returns an empty sequence`` () = task {
-    let! sq = TaskSeq.empty<string> |> TaskSeq.toSeqCachedAsync
-    Seq.isEmpty sq |> should be True
-    Seq.length sq |> should equal 0
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-empty returns an empty sequence`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-isEmpty returns true for empty`` () = task {
-    let! isEmpty = TaskSeq.empty<string> |> TaskSeq.isEmpty
-    isEmpty |> should be True
-}
+        task {
+            let! sq = TaskSeq.empty<string> |> TaskSeq.toSeqCachedAsync
+            Seq.isEmpty sq |> should be True
+            Seq.length sq |> should equal 0
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-isEmpty returns false for non-empty`` () = task {
-    let! isEmpty = taskSeq { yield 42 } |> TaskSeq.isEmpty
-    isEmpty |> should be False
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-isEmpty returns true for empty`` () =
+        logStart output
+
+        task {
+            let! isEmpty = TaskSeq.empty<string> |> TaskSeq.isEmpty
+            isEmpty |> should be True
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-isEmpty returns false for non-empty`` () =
+        logStart output
+
+        task {
+            let! isEmpty = taskSeq { yield 42 } |> TaskSeq.isEmpty
+            isEmpty |> should be False
+        }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.Other.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.Other.fs
@@ -8,7 +8,7 @@ open FSharpy
 
 type ``Other functions``(output) =
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-empty returns an empty sequence`` () =
         logStart output
 
@@ -18,7 +18,7 @@ type ``Other functions``(output) =
             Seq.length sq |> should equal 0
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-isEmpty returns true for empty`` () =
         logStart output
 
@@ -27,7 +27,7 @@ type ``Other functions``(output) =
             isEmpty |> should be True
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-isEmpty returns false for non-empty`` () =
         logStart output
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
@@ -22,7 +22,7 @@ open System.Collections.Generic
 
 type ``Conversion-To``(output) =
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-toArrayAsync should succeed`` () =
         logStart output
 
@@ -32,7 +32,7 @@ type ``Conversion-To``(output) =
             results |> should equal [| 1..10 |]
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-toListAsync should succeed`` () =
         logStart output
 
@@ -42,7 +42,7 @@ type ``Conversion-To``(output) =
             results |> should equal [ 1..10 ]
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-toSeqCachedAsync should succeed`` () =
         logStart output
 
@@ -52,7 +52,7 @@ type ``Conversion-To``(output) =
             results |> Seq.toArray |> should equal [| 1..10 |]
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-toIListAsync should succeed`` () =
         logStart output
 
@@ -62,7 +62,7 @@ type ``Conversion-To``(output) =
             results |> Seq.toArray |> should equal [| 1..10 |]
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-toResizeArray should succeed`` () =
         logStart output
 
@@ -72,19 +72,19 @@ type ``Conversion-To``(output) =
             results |> Seq.toArray |> should equal [| 1..10 |]
         }
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-toArray should succeed and be blocking`` () =
         let tq = createDummyTaskSeq 10
         let (results: _[]) = tq |> TaskSeq.toArray
         results |> should equal [| 1..10 |]
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-toList should succeed and be blocking`` () =
         let tq = createDummyTaskSeq 10
         let (results: list<_>) = tq |> TaskSeq.toList
         results |> should equal [ 1..10 ]
 
-    [<Fact(Timeout = 10_000)>]
+    [<Fact(Skip = "CI test runner chokes!")>]
     let ``TaskSeq-toSeqCached should succeed and be blocking`` () =
         let tq = createDummyTaskSeq 10
         let (results: seq<_>) = tq |> TaskSeq.toSeqCached

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.``Conversion-To``
+namespace FSharpy.Tests
 
 open Xunit
 open FsUnit.Xunit
@@ -20,55 +20,72 @@ open System.Collections.Generic
 ///                                                                      ///
 ////////////////////////////////////////////////////////////////////////////
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-toArrayAsync should succeed`` () = task {
-    let tq = createDummyTaskSeq 10
-    let! (results: _[]) = tq |> TaskSeq.toArrayAsync
-    results |> should equal [| 1..10 |]
-}
+type ``Conversion-To``(output) =
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-toListAsync should succeed`` () = task {
-    let tq = createDummyTaskSeq 10
-    let! (results: list<_>) = tq |> TaskSeq.toListAsync
-    results |> should equal [ 1..10 ]
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-toArrayAsync should succeed`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-toSeqCachedAsync should succeed`` () = task {
-    let tq = createDummyTaskSeq 10
-    let! (results: seq<_>) = tq |> TaskSeq.toSeqCachedAsync
-    results |> Seq.toArray |> should equal [| 1..10 |]
-}
+        task {
+            let tq = createDummyTaskSeq 10
+            let! (results: _[]) = tq |> TaskSeq.toArrayAsync
+            results |> should equal [| 1..10 |]
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-toIListAsync should succeed`` () = task {
-    let tq = createDummyTaskSeq 10
-    let! (results: IList<_>) = tq |> TaskSeq.toIListAsync
-    results |> Seq.toArray |> should equal [| 1..10 |]
-}
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-toListAsync should succeed`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-toResizeArray should succeed`` () = task {
-    let tq = createDummyTaskSeq 10
-    let! (results: ResizeArray<_>) = tq |> TaskSeq.toResizeArrayAsync
-    results |> Seq.toArray |> should equal [| 1..10 |]
-}
+        task {
+            let tq = createDummyTaskSeq 10
+            let! (results: list<_>) = tq |> TaskSeq.toListAsync
+            results |> should equal [ 1..10 ]
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-toArray should succeed and be blocking`` () =
-    let tq = createDummyTaskSeq 10
-    let (results: _[]) = tq |> TaskSeq.toArray
-    results |> should equal [| 1..10 |]
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-toSeqCachedAsync should succeed`` () =
+        logStart output
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-toList should succeed and be blocking`` () =
-    let tq = createDummyTaskSeq 10
-    let (results: list<_>) = tq |> TaskSeq.toList
-    results |> should equal [ 1..10 ]
+        task {
+            let tq = createDummyTaskSeq 10
+            let! (results: seq<_>) = tq |> TaskSeq.toSeqCachedAsync
+            results |> Seq.toArray |> should equal [| 1..10 |]
+        }
 
-[<Fact(Timeout = 10_000)>]
-let ``TaskSeq-toSeqCached should succeed and be blocking`` () =
-    let tq = createDummyTaskSeq 10
-    let (results: seq<_>) = tq |> TaskSeq.toSeqCached
-    results |> Seq.toArray |> should equal [| 1..10 |]
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-toIListAsync should succeed`` () =
+        logStart output
+
+        task {
+            let tq = createDummyTaskSeq 10
+            let! (results: IList<_>) = tq |> TaskSeq.toIListAsync
+            results |> Seq.toArray |> should equal [| 1..10 |]
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-toResizeArray should succeed`` () =
+        logStart output
+
+        task {
+            let tq = createDummyTaskSeq 10
+            let! (results: ResizeArray<_>) = tq |> TaskSeq.toResizeArrayAsync
+            results |> Seq.toArray |> should equal [| 1..10 |]
+        }
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-toArray should succeed and be blocking`` () =
+        let tq = createDummyTaskSeq 10
+        let (results: _[]) = tq |> TaskSeq.toArray
+        results |> should equal [| 1..10 |]
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-toList should succeed and be blocking`` () =
+        let tq = createDummyTaskSeq 10
+        let (results: list<_>) = tq |> TaskSeq.toList
+        results |> should equal [ 1..10 ]
+
+    [<Fact(Timeout = 10_000)>]
+    let ``TaskSeq-toSeqCached should succeed and be blocking`` () =
+        let tq = createDummyTaskSeq 10
+        let (results: seq<_>) = tq |> TaskSeq.toSeqCached
+        results |> Seq.toArray |> should equal [| 1..10 |]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
@@ -20,54 +20,54 @@ open System.Collections.Generic
 ///                                                                      ///
 ////////////////////////////////////////////////////////////////////////////
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-toArrayAsync should succeed`` () = task {
     let tq = createDummyTaskSeq 10
     let! (results: _[]) = tq |> TaskSeq.toArrayAsync
     results |> should equal [| 1..10 |]
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-toListAsync should succeed`` () = task {
     let tq = createDummyTaskSeq 10
     let! (results: list<_>) = tq |> TaskSeq.toListAsync
     results |> should equal [ 1..10 ]
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-toSeqCachedAsync should succeed`` () = task {
     let tq = createDummyTaskSeq 10
     let! (results: seq<_>) = tq |> TaskSeq.toSeqCachedAsync
     results |> Seq.toArray |> should equal [| 1..10 |]
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-toIListAsync should succeed`` () = task {
     let tq = createDummyTaskSeq 10
     let! (results: IList<_>) = tq |> TaskSeq.toIListAsync
     results |> Seq.toArray |> should equal [| 1..10 |]
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-toResizeArray should succeed`` () = task {
     let tq = createDummyTaskSeq 10
     let! (results: ResizeArray<_>) = tq |> TaskSeq.toResizeArrayAsync
     results |> Seq.toArray |> should equal [| 1..10 |]
 }
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-toArray should succeed and be blocking`` () =
     let tq = createDummyTaskSeq 10
     let (results: _[]) = tq |> TaskSeq.toArray
     results |> should equal [| 1..10 |]
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-toList should succeed and be blocking`` () =
     let tq = createDummyTaskSeq 10
     let (results: list<_>) = tq |> TaskSeq.toList
     results |> should equal [ 1..10 ]
 
-[<Fact>]
+[<Fact(Timeout = 10_000)>]
 let ``TaskSeq-toSeqCached should succeed and be blocking`` () =
     let tq = createDummyTaskSeq 10
     let (results: seq<_>) = tq |> TaskSeq.toSeqCached

--- a/src/FSharpy.TaskSeq.Test/TestUtils.fs
+++ b/src/FSharpy.TaskSeq.Test/TestUtils.fs
@@ -1,4 +1,4 @@
-﻿namespace FSharpy.Tests
+namespace FSharpy.Tests
 
 open System
 open System.Threading
@@ -65,12 +65,13 @@ type DummyTaskFactory(µsecMin: int64<µs>, µsecMax: int64<µs>) =
         //let! _ = Task.Delay(rnd ())
         let! _ = Task.Delay 0 // this creates a resume state, which seems more efficient than SpinWait.SpinOnce, see DelayHelper.
         DelayHelper.delayMicroseconds (rnd ()) false
-        x <- x + 1
+        Interlocked.Increment &x |> ignore
+        //x <- x + 1
         return x // this dereferences the variable
     }
 
     let runTaskDirect i = backgroundTask {
-        x <- x + 1
+        Interlocked.Increment &x |> ignore
         return x
     }
 

--- a/src/FSharpy.TaskSeq.Test/TestUtils.fs
+++ b/src/FSharpy.TaskSeq.Test/TestUtils.fs
@@ -8,6 +8,8 @@ open System.Diagnostics
 open FsToolkit.ErrorHandling
 
 open FSharpy
+open Xunit.Abstractions
+open System.Reflection
 
 /// Milliseconds
 [<Measure>]
@@ -16,6 +18,13 @@ type ms
 /// Microseconds
 [<Measure>]
 type µs
+
+[<AutoOpen>]
+module Log =
+    let inline logStart (output: ITestOutputHelper) =
+        let name = MethodBase.GetCurrentMethod().Name
+        output.WriteLine $"Starting test: {name}"
+
 
 /// Helpers for short waits, as Task.Delay has about 15ms precision.
 /// Inspired by IoT code: https://github.com/dotnet/iot/pull/235/files

--- a/src/FSharpy.TaskSeq.v3.ncrunchsolution
+++ b/src/FSharpy.TaskSeq.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>


### PR DESCRIPTION
_(see at bottom for original issue description and research)_

## xUnit bug, see [this report](https://github.com/xunit/xunit/issues/2587)

It turns out that if the following is true, `xUnit` ends up in a deadlock in CI, but not locally:

* You have two or more `Task<unit>`-returning tests
* These tests live in separate types or modules
* At least two of the tasks yield. 
 
The example in https://github.com/xunit/xunit/issues/2587 is given as two tasks that do a `Task.Delay(1)`, which, as we all know, will yield and pause for the length of at least one timer event (which is `15.6ms` on most systems). Even though there are no shared variables, it leads to a deadlock.

A good analysis is in this comment: https://github.com/dotnet/BenchmarkDotNet/pull/2114#issuecomment-1257248411.
Possibly related: https://github.com/dotnet/corefx/pull/559 (i.e., that the diff between local and CI is that on CI there are simply not enough threads in the thread pool and thread starvation causes the deadlock).

## Solution (for now)

There are only two possible solutions that I can think of, given that the issue isn't likely to be solved any time soon (this is not a critique, it is just a nature of this kind of problems):

 - [ ] Move to NUnit (neither NUnit and MSUnit have this problem, see https://github.com/dotnet/BenchmarkDotNet/pull/2114#issuecomment-1262460875)
 - [x] Disable parallelism, though this is unfavorable as we are writing an `async` library for `IAsyncEnumerable<_>` and we really want to catch any potential parallelism issues.

-----------
## Original text

Trial and error approach:

 - [x] In [#23][1]: we already tried removing specific tests, but this didn't appear to help
 - [x] In [#23][1]: we enabled a global timeout through `dotnet test` with `--blame-hang-timeout 15000ms` on the commandline in CI
 - [x] In  [#23][1]: observed that with `[<assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)>]` the tests run fine
 - [x] Observed that (so far) local repro does not exhibit this issue
        Follow up: running in "Crunch mode" (using NCrunch) for several hours using as many parallel threads as possible gives no issues.
 - [x] Re-enabled parallel testing (this issue) to be able to see if the behavior persists
        Follow-up: the green test runs were either non parallel, or self-parallelized, still unclear. Edit: see above.
 - [x] Run several times in CI to ensure it is stable
       Follow up: it is not. It is an xUnit bug for their CI runner.
 - [x] Run the tests on CI using a reflection-based "grab all tests and run in parallel" approach and crunch multiple times.
       Follow up: CI or Windows or dotnet version on CI has nothing to do with this issue, these tests run fine.
 - [ ] Attempt different `dotnet test` configurations

[1]: https://github.com/abelbraaksma/TaskSeq/pull/27