### PR TITLE
Use Interlocked.Increment for our dummy tasks in the tests

### DIFF
--- a/src/FSharpy.TaskSeq.Test/TestUtils.fs
+++ b/src/FSharpy.TaskSeq.Test/TestUtils.fs
@@ -1,4 +1,4 @@
-﻿namespace FSharpy.Tests
+namespace FSharpy.Tests
 
 open System
 open System.Threading
@@ -65,12 +65,13 @@ type DummyTaskFactory(µsecMin: int64<µs>, µsecMax: int64<µs>) =
         //let! _ = Task.Delay(rnd ())
         let! _ = Task.Delay 0 // this creates a resume state, which seems more efficient than SpinWait.SpinOnce, see DelayHelper.
         DelayHelper.delayMicroseconds (rnd ()) false
-        x <- x + 1
+        Interlocked.Increment &x |> ignore
+        //x <- x + 1
         return x // this dereferences the variable
     }
 
     let runTaskDirect i = backgroundTask {
-        x <- x + 1
+        Interlocked.Increment &x |> ignore
         return x
     }
 


### PR DESCRIPTION
While this hasn't yet showed as a race condition, and even if it did, it wouldn't pose a big problem (the "wrong approach" tests merely test that if these tasks are run incorrectly, you get the wrong output, which remains the case when racing happens, and the "good approach" tests will run the tasks in order, awaiting them one by one, so these cannot race at all), adding `Interlocked.Increment` is just good practice if you have a shared variable in what is potentially run on multiple threads.

Note that currently, these tasks are _not_ run on multiple threads when they belong to a single sequence of tasks created by the generator. We may, though, add such test in the future.