### PR TITLE
Get to 100% coverage, add tests for `TaskSeq.zip`, `mapi`, `iter`, `exactlyOne` and async variants

### DIFF
--- a/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
+++ b/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="TestUtils.fs" />
     <Compile Include="TaskSeq.Choose.Tests.fs" />
     <Compile Include="TaskSeq.Collect.Tests.fs" />
+    <Compile Include="TaskSeq.ExactlyOne.Tests.fs" />
     <Compile Include="TaskSeq.Filter.Tests.fs" />
     <Compile Include="TaskSeq.Find.Tests.fs" />
     <Compile Include="TaskSeq.Fold.Tests.fs" />

--- a/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
+++ b/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="TaskSeq.Last.Tests.fs" />
     <Compile Include="TaskSeq.Map.Tests.fs" />
     <Compile Include="TaskSeq.Pick.Tests.fs" />
+    <Compile Include="TaskSeq.Zip.Tests.fs" />
     <Compile Include="TaskSeq.ToXXX.Tests.fs" />
     <Compile Include="TaskSeq.OfXXX.Tests.fs" />
     <Compile Include="TaskSeq.Tests.Other.fs" />

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
@@ -10,13 +10,6 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 [<Fact>]
-let ``ZHang timeout test`` () = task {
-    let! empty = Task.Delay 30
-
-    empty |> should be Null
-}
-
-[<Fact>]
 let ``TaskSeq-choose on an empty sequence`` () = task {
     let! empty =
         TaskSeq.empty
@@ -50,7 +43,7 @@ let ``TaskSeq-choose can convert and filter`` () = task {
 let ``TaskSeq-chooseAsync can convert and filter`` () = task {
     let! alphabet =
         createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.choose (fun number -> if number <= 26 then Some(char number + '@') else None)
+        |> TaskSeq.chooseAsync (fun number -> task { return if number <= 26 then Some(char number + '@') else None })
         |> TaskSeq.toArrayAsync
 
     String alphabet |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
@@ -6,6 +6,12 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+let validateSequence sequence =
+    sequence
+    |> Seq.map string
+    |> String.concat ""
+    |> should equal "ABBCCDDEEFFGGHHIIJJK"
+
 [<Fact>]
 let ``TaskSeq-collect operates in correct order`` () = task {
     let! sq =
@@ -16,10 +22,22 @@ let ``TaskSeq-collect operates in correct order`` () = task {
         })
         |> TaskSeq.toSeqCachedAsync
 
-    sq
-    |> Seq.map string
-    |> String.concat ""
-    |> should equal "ABBCCDDEEFFGGHHIIJJK"
+    validateSequence sq
+}
+
+[<Fact>]
+let ``TaskSeq-collectAsync operates in correct order`` () = task {
+    let! sq =
+        createDummyTaskSeq 10
+        |> TaskSeq.collectAsync (fun item -> task {
+            return taskSeq {
+                yield char (item + 64)
+                yield char (item + 65)
+            }
+        })
+        |> TaskSeq.toSeqCachedAsync
+
+    validateSequence sq
 }
 
 [<Fact>]
@@ -32,10 +50,42 @@ let ``TaskSeq-collectSeq operates in correct order`` () = task {
         })
         |> TaskSeq.toSeqCachedAsync
 
-    sq
-    |> Seq.map string
-    |> String.concat ""
-    |> should equal "ABBCCDDEEFFGGHHIIJJK"
+    validateSequence sq
+}
+
+[<Fact>]
+let ``TaskSeq-collectSeq with arrays operates in correct order`` () = task {
+    let! sq =
+        createDummyTaskSeq 10
+        |> TaskSeq.collectSeq (fun item -> [| char (item + 64); char (item + 65) |])
+        |> TaskSeq.toArrayAsync
+
+    validateSequence sq
+}
+
+[<Fact>]
+let ``TaskSeq-collectSeqAsync operates in correct order`` () = task {
+    let! sq =
+        createDummyTaskSeq 10
+        |> TaskSeq.collectSeqAsync (fun item -> task {
+            return seq {
+                yield char (item + 64)
+                yield char (item + 65)
+            }
+        })
+        |> TaskSeq.toSeqCachedAsync
+
+    validateSequence sq
+}
+
+[<Fact>]
+let ``TaskSeq-collectSeqAsync with arrays operates in correct order`` () = task {
+    let! sq =
+        createDummyTaskSeq 10
+        |> TaskSeq.collectSeqAsync (fun item -> task { return [| char (item + 64); char (item + 65) |] })
+        |> TaskSeq.toArrayAsync
+
+    validateSequence sq
 }
 
 [<Fact>]
@@ -49,10 +99,30 @@ let ``TaskSeq-collect with empty task sequences`` () = task {
 }
 
 [<Fact>]
+let ``TaskSeq-collectAsync with empty task sequences`` () = task {
+    let! sq =
+        createDummyTaskSeq 10
+        |> TaskSeq.collectAsync (fun _ -> task { return TaskSeq.empty<string> })
+        |> TaskSeq.toSeqCachedAsync
+
+    Seq.isEmpty sq |> should be True
+}
+
+[<Fact>]
 let ``TaskSeq-collectSeq with empty sequences`` () = task {
     let! sq =
         createDummyTaskSeq 10
         |> TaskSeq.collectSeq (fun _ -> Seq.empty<int>)
+        |> TaskSeq.toSeqCachedAsync
+
+    Seq.isEmpty sq |> should be True
+}
+
+[<Fact>]
+let ``TaskSeq-collectSeqAsync with empty sequences`` () = task {
+    let! sq =
+        createDummyTaskSeq 10
+        |> TaskSeq.collectSeqAsync (fun _ -> task { return Array.empty<int> })
         |> TaskSeq.toSeqCachedAsync
 
     Seq.isEmpty sq |> should be True

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
@@ -57,9 +57,3 @@ let ``TaskSeq-collectSeq with empty sequences`` () = task {
 
     Seq.isEmpty sq |> should be True
 }
-
-[<Fact>]
-let ``TaskSeq-empty is empty`` () = task {
-    let! sq = TaskSeq.empty<string> |> TaskSeq.toSeqCachedAsync
-    Seq.isEmpty sq |> should be True
-}

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
@@ -1,0 +1,57 @@
+module FSharpy.Tests.Head
+
+open System
+open Xunit
+open FsUnit.Xunit
+open FsToolkit.ErrorHandling
+
+open FSharpy
+
+
+[<Fact>]
+let ``TaskSeq-head throws on empty sequences`` () = task {
+    fun () -> TaskSeq.empty<string> |> TaskSeq.head |> Task.ignore
+    |> should throwAsyncExact typeof<ArgumentException>
+}
+
+[<Fact>]
+let ``TaskSeq-head throws on empty sequences - variant`` () = task {
+    fun () -> taskSeq { do () } |> TaskSeq.head |> Task.ignore
+    |> should throwAsyncExact typeof<ArgumentException>
+}
+
+[<Fact>]
+let ``TaskSeq-tryHead returns None on empty sequences`` () = task {
+    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryHead
+    nothing |> should be None'
+}
+
+[<Fact>]
+let ``TaskSeq-head gets the first item in a longer sequence`` () = task {
+    let! head = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50 |> TaskSeq.head
+
+    head |> should equal 1
+}
+
+[<Fact>]
+let ``TaskSeq-head gets the only item in a singleton sequence`` () = task {
+    let! head = taskSeq { yield 10 } |> TaskSeq.head
+    head |> should equal 10
+}
+
+[<Fact>]
+let ``TaskSeq-tryHead gets the first item in a longer sequence`` () = task {
+    let! head =
+        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        |> TaskSeq.tryHead
+
+    head |> should be Some'
+    head |> should equal (Some 1)
+}
+
+[<Fact>]
+let ``TaskSeq-tryHead gets the only item in a singleton sequence`` () = task {
+    let! head = taskSeq { yield 10 } |> TaskSeq.tryHead
+    head |> should be Some'
+    head |> should equal (Some 10)
+}

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Head
+module FSharpy.Tests.ExactlyOne
 
 open System
 open Xunit
@@ -9,49 +9,91 @@ open FSharpy
 
 
 [<Fact>]
-let ``TaskSeq-head throws on empty sequences`` () = task {
-    fun () -> TaskSeq.empty<string> |> TaskSeq.head |> Task.ignore
+let ``TaskSeq-exactlyOne throws on empty sequences`` () = task {
+    fun () -> TaskSeq.empty<string> |> TaskSeq.exactlyOne |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
 [<Fact>]
-let ``TaskSeq-head throws on empty sequences - variant`` () = task {
-    fun () -> taskSeq { do () } |> TaskSeq.head |> Task.ignore
+let ``TaskSeq-exactlyOne throws on empty sequences - variant`` () = task {
+    fun () -> taskSeq { do () } |> TaskSeq.exactlyOne |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
 [<Fact>]
-let ``TaskSeq-tryHead returns None on empty sequences`` () = task {
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryHead
+let ``TaskSeq-tryExactlyOne returns None on empty sequences`` () = task {
+    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryExactlyOne
     nothing |> should be None'
 }
 
 [<Fact>]
-let ``TaskSeq-head gets the first item in a longer sequence`` () = task {
-    let! head = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50 |> TaskSeq.head
-
-    head |> should equal 1
+let ``TaskSeq-exactlyOne throws for a sequence of length = two`` () = task {
+    fun () ->
+        taskSeq {
+            yield 1
+            yield 2
+        }
+        |> TaskSeq.exactlyOne
+        |> Task.ignore
+    |> should throwAsyncExact typeof<ArgumentException>
 }
 
 [<Fact>]
-let ``TaskSeq-head gets the only item in a singleton sequence`` () = task {
-    let! head = taskSeq { yield 10 } |> TaskSeq.head
-    head |> should equal 10
+let ``TaskSeq-exactlyOne throws for a sequence of length = two - variant`` () = task {
+    fun () ->
+        createDummyTaskSeqWith 50L<µs> 1000L<µs> 2
+        |> TaskSeq.exactlyOne
+        |> Task.ignore
+    |> should throwAsyncExact typeof<ArgumentException>
+}
+
+
+[<Fact>]
+let ``TaskSeq-exactlyOne throws with a larger sequence`` () = task {
+    fun () ->
+        createDummyTaskSeqWith 50L<µs> 300L<µs> 200
+        |> TaskSeq.exactlyOne
+        |> Task.ignore
+    |> should throwAsyncExact typeof<ArgumentException>
 }
 
 [<Fact>]
-let ``TaskSeq-tryHead gets the first item in a longer sequence`` () = task {
-    let! head =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryHead
+let ``TaskSeq-tryExactlyOne returns None with a larger sequence`` () = task {
+    let! nothing =
+        createDummyTaskSeqWith 50L<µs> 300L<µs> 20
+        |> TaskSeq.tryExactlyOne
 
-    head |> should be Some'
-    head |> should equal (Some 1)
+    nothing |> should be None'
 }
 
 [<Fact>]
-let ``TaskSeq-tryHead gets the only item in a singleton sequence`` () = task {
-    let! head = taskSeq { yield 10 } |> TaskSeq.tryHead
-    head |> should be Some'
-    head |> should equal (Some 10)
+let ``TaskSeq-exactlyOne gets the only item in a singleton sequence`` () = task {
+    let! exactlyOne = taskSeq { yield 10 } |> TaskSeq.exactlyOne
+    exactlyOne |> should equal 10
+}
+
+[<Fact>]
+let ``TaskSeq-tryExactlyOne gets the only item in a singleton sequence`` () = task {
+    let! exactlyOne = taskSeq { yield 10 } |> TaskSeq.tryExactlyOne
+    exactlyOne |> should be Some'
+    exactlyOne |> should equal (Some 10)
+}
+
+[<Fact>]
+let ``TaskSeq-exactlyOne gets the only item in a singleton sequence - variant`` () = task {
+    let! exactlyOne =
+        createLongerDummyTaskSeq 50<ms> 300<ms> 1
+        |> TaskSeq.exactlyOne
+
+    exactlyOne |> should equal 1
+}
+
+[<Fact>]
+let ``TaskSeq-tryExactlyOne gets the only item in a singleton sequence - variant`` () = task {
+    let! exactlyOne =
+        createLongerDummyTaskSeq 50<ms> 300<ms> 1
+        |> TaskSeq.tryExactlyOne
+
+    exactlyOne |> should be Some'
+    exactlyOne |> should equal (Some 1)
 }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -2,10 +2,24 @@ module FSharpy.Tests.Iter
 
 open Xunit
 open FsUnit.Xunit
-open FsToolkit.ErrorHandling
 
 open FSharpy
 
+[<Fact>]
+let ``TaskSeq-iteri does nothing on empty sequences`` () = task {
+    let tq = createDummyTaskSeq 10
+    let mutable sum = -1
+    do! TaskSeq.empty |> TaskSeq.iteri (fun i _ -> sum <- sum + i)
+    sum |> should equal -1
+}
+
+[<Fact>]
+let ``TaskSeq-iter does nothing on empty sequences`` () = task {
+    let tq = createDummyTaskSeq 10
+    let mutable sum = -1
+    do! TaskSeq.empty |> TaskSeq.iter (fun i -> sum <- sum + i)
+    sum |> should equal -1
+}
 
 [<Fact>]
 let ``TaskSeq-iteri should go over all items`` () = task {

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -6,6 +6,11 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+let validateSequence sequence =
+    sequence
+    |> Seq.map string
+    |> String.concat ""
+    |> should equal "ABCDEFGHIJ"
 
 [<Fact>]
 let ``TaskSeq-map maps in correct order`` () = task {
@@ -14,10 +19,47 @@ let ``TaskSeq-map maps in correct order`` () = task {
         |> TaskSeq.map (fun item -> char (item + 64))
         |> TaskSeq.toSeqCachedAsync
 
-    sq
-    |> Seq.map string
-    |> String.concat ""
-    |> should equal "ABCDEFGHIJ"
+    validateSequence sq
+}
+
+[<Fact>]
+let ``TaskSeq-mapi maps in correct order`` () = task {
+    let! sq =
+        createDummyTaskSeq 10
+        |> TaskSeq.mapi (fun i _ -> char (i + 65))
+        |> TaskSeq.toSeqCachedAsync
+
+    validateSequence sq
+}
+
+[<Fact>]
+let ``TaskSeq-map can access mutables which are mutated in correct order`` () = task {
+    let mutable sum = 0
+
+    let! sq =
+        createDummyTaskSeq 10
+        |> TaskSeq.map (fun item ->
+            sum <- sum + 1
+            char (sum + 64))
+        |> TaskSeq.toSeqCachedAsync
+
+    sum |> should equal 10
+    validateSequence sq
+}
+
+[<Fact>]
+let ``TaskSeq-mapi can access mutables which are mutated in correct order`` () = task {
+    let mutable sum = 0
+
+    let! sq =
+        createDummyTaskSeq 10
+        |> TaskSeq.mapi (fun i _ ->
+            sum <- i + 1
+            char (sum + 64))
+        |> TaskSeq.toSeqCachedAsync
+
+    sum |> should equal 10
+    validateSequence sq
 }
 
 [<Fact>]
@@ -27,8 +69,48 @@ let ``TaskSeq-mapAsync maps in correct order`` () = task {
         |> TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
         |> TaskSeq.toSeqCachedAsync
 
-    sq
-    |> Seq.map string
-    |> String.concat ""
-    |> should equal "ABCDEFGHIJ"
+    validateSequence sq
+}
+
+[<Fact>]
+let ``TaskSeq-mapiAsync maps in correct order`` () = task {
+    let! sq =
+        createDummyTaskSeq 10
+        |> TaskSeq.mapiAsync (fun i _ -> task { return char (i + 65) })
+        |> TaskSeq.toSeqCachedAsync
+
+    validateSequence sq
+}
+
+
+[<Fact>]
+let ``TaskSeq-mapAsync can access mutables which are mutated in correct order`` () = task {
+    let mutable sum = 0
+
+    let! sq =
+        createDummyTaskSeq 10
+        |> TaskSeq.mapAsync (fun item -> task {
+            sum <- sum + 1
+            return char (sum + 64)
+        })
+        |> TaskSeq.toSeqCachedAsync
+
+    sum |> should equal 10
+    validateSequence sq
+}
+
+[<Fact>]
+let ``TaskSeq-mapiAsync can access mutables which are mutated in correct order`` () = task {
+    let mutable data = '0'
+
+    let! sq =
+        createDummyTaskSeq 10
+        |> TaskSeq.mapiAsync (fun i _ -> task {
+            data <- char (i + 65)
+            return data
+        })
+        |> TaskSeq.toSeqCachedAsync
+
+    data |> should equal (char 74)
+    validateSequence sq
 }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
@@ -48,6 +48,12 @@ let ``TaskSeq-ofTaskSeq should succeed`` () =
     |> validateSequence
 
 [<Fact>]
+let ``TaskSeq-ofResizeArray should succeed`` () =
+    ResizeArray [ 0..9 ]
+    |> TaskSeq.ofResizeArray
+    |> validateSequence
+
+[<Fact>]
 let ``TaskSeq-ofArray should succeed`` () = Array.init 10 id |> TaskSeq.ofArray |> validateSequence
 
 [<Fact>]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.Other.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.Other.fs
@@ -1,5 +1,6 @@
 module FSharpy.Tests.``Other functions``
 
+open System.Threading.Tasks
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
@@ -15,6 +16,54 @@ let ``TaskSeq-empty returns an empty sequence`` () = task {
 }
 
 [<Fact>]
+let ``TaskSeq-empty returns an empty sequence - variant`` () = task {
+    let! isEmpty = TaskSeq.empty<string> |> TaskSeq.isEmpty
+    isEmpty |> should be True
+}
+
+[<Fact>]
+let ``TaskSeq-empty in a taskSeq context`` () = task {
+    let! sq =
+        taskSeq { yield! TaskSeq.empty<string> }
+        |> TaskSeq.toArrayAsync
+
+    Array.isEmpty sq |> should be True
+}
+
+[<Fact>]
+let ``TaskSeq-empty of unit in a taskSeq context`` () = task {
+    let! sq =
+        taskSeq { yield! TaskSeq.empty<unit> }
+        |> TaskSeq.toArrayAsync
+
+    Array.isEmpty sq |> should be True
+}
+
+[<Fact>]
+let ``TaskSeq-empty of more complex type in a taskSeq context`` () = task {
+    let! sq =
+        taskSeq { yield! TaskSeq.empty<Result<Task<string>, int>> }
+        |> TaskSeq.toArrayAsync
+
+    Array.isEmpty sq |> should be True
+}
+
+[<Fact>]
+let ``TaskSeq-empty multiple times in a taskSeq context`` () = task {
+    let! sq =
+        taskSeq {
+            yield! TaskSeq.empty<string>
+            yield! TaskSeq.empty<string>
+            yield! TaskSeq.empty<string>
+            yield! TaskSeq.empty<string>
+            yield! TaskSeq.empty<string>
+        }
+        |> TaskSeq.toArrayAsync
+
+    Array.isEmpty sq |> should be True
+}
+
+[<Fact>]
 let ``TaskSeq-isEmpty returns true for empty`` () = task {
     let! isEmpty = TaskSeq.empty<string> |> TaskSeq.isEmpty
     isEmpty |> should be True
@@ -23,5 +72,14 @@ let ``TaskSeq-isEmpty returns true for empty`` () = task {
 [<Fact>]
 let ``TaskSeq-isEmpty returns false for non-empty`` () = task {
     let! isEmpty = taskSeq { yield 42 } |> TaskSeq.isEmpty
+    isEmpty |> should be False
+}
+
+[<Fact>]
+let ``TaskSeq-isEmpty returns false for delayed non-empty sequence`` () = task {
+    let! isEmpty =
+        createLongerDummyTaskSeq 200<ms> 400<ms> 3
+        |> TaskSeq.isEmpty
+
     isEmpty |> should be False
 }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
@@ -85,6 +85,15 @@ let ``TaskSeq-zip throws on unequal lengths`` () = task {
 }
 
 [<Fact>]
+let ``TaskSeq-zip throws on unequal lengths, inverted args`` () = task {
+    let one = createDummyTaskSeq 1
+    let combined = TaskSeq.zip one TaskSeq.empty
+
+    fun () -> TaskSeq.toArrayAsync combined |> Task.ignore
+    |> should throwAsyncExact typeof<ArgumentException>
+}
+
+[<Fact>]
 let ``TaskSeq-zip can zip empty arrays`` () = task {
     let combined = TaskSeq.zip TaskSeq.empty<int> TaskSeq.empty<string>
     let! combined = TaskSeq.toArrayAsync combined

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
@@ -74,20 +74,30 @@ let ``TaskSeq-zip zips different types`` () = task {
     combined |> should equal [| ("one", 42L); ("two", 43L) |]
 }
 
-[<Fact>]
-let ``TaskSeq-zip throws on unequal lengths`` () = task {
-    let one = createDummyTaskSeq 10
-    let two = createDummyTaskSeq 11
-    let combined = TaskSeq.zip one two
+[<Theory; InlineData true; InlineData false>]
+let ``TaskSeq-zip throws on unequal lengths, variant`` leftThrows = task {
+    let long = createDummyTaskSeq 11
+    let short = createDummyTaskSeq 10
+
+    let combined =
+        if leftThrows then
+            TaskSeq.zip short long
+        else
+            TaskSeq.zip long short
 
     fun () -> TaskSeq.toArrayAsync combined |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
-[<Fact>]
-let ``TaskSeq-zip throws on unequal lengths, inverted args`` () = task {
+[<Theory; InlineData true; InlineData false>]
+let ``TaskSeq-zip throws on unequal lengths with empty seq`` leftThrows = task {
     let one = createDummyTaskSeq 1
-    let combined = TaskSeq.zip one TaskSeq.empty
+
+    let combined =
+        if leftThrows then
+            TaskSeq.zip TaskSeq.empty one
+        else
+            TaskSeq.zip one TaskSeq.empty
 
     fun () -> TaskSeq.toArrayAsync combined |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
@@ -1,0 +1,93 @@
+module FSharpy.Tests.Zip
+
+open System
+open Xunit
+open FsUnit.Xunit
+open FsToolkit.ErrorHandling
+
+open FSharpy
+
+[<Fact>]
+let ``TaskSeq-zip zips in correct order`` () = task {
+    let one = createDummyTaskSeq 10
+    let two = createDummyTaskSeq 10
+    let combined = TaskSeq.zip one two
+    let! combined = TaskSeq.toArrayAsync combined
+
+    combined
+    |> Array.forall (fun (x, y) -> x = y)
+    |> should be True
+
+    combined |> should be (haveLength 10)
+
+    combined
+    |> should equal (Array.init 10 (fun x -> x + 1, x + 1))
+}
+
+[<Fact>]
+let ``TaskSeq-zip zips in correct order for differently delayed sequences`` () = task {
+    let one = createDummyDirectTaskSeq 10
+    let two = createDummyTaskSeq 10
+    let combined = TaskSeq.zip one two
+    let! combined = TaskSeq.toArrayAsync combined
+
+    combined
+    |> Array.forall (fun (x, y) -> x = y)
+    |> should be True
+
+    combined |> should be (haveLength 10)
+
+    combined
+    |> should equal (Array.init 10 (fun x -> x + 1, x + 1))
+}
+
+[<Theory; InlineData 100; InlineData 1_000; InlineData 10_000; InlineData 100_000>]
+let ``TaskSeq-zip zips large sequences just fine`` length = task {
+    let one = createDummyTaskSeqWith 10L<µs> 50L<µs> length
+    let two = createDummyDirectTaskSeq length
+    let combined = TaskSeq.zip one two
+    let! combined = TaskSeq.toArrayAsync combined
+
+    combined
+    |> Array.forall (fun (x, y) -> x = y)
+    |> should be True
+
+    combined |> should be (haveLength length)
+    combined |> Array.last |> should equal (length, length)
+}
+
+[<Fact>]
+let ``TaskSeq-zip zips different types`` () = task {
+    let one = taskSeq {
+        yield "one"
+        yield "two"
+    }
+
+    let two = taskSeq {
+        yield 42L
+        yield 43L
+    }
+
+    let combined = TaskSeq.zip one two
+    let! combined = TaskSeq.toArrayAsync combined
+
+    combined |> should equal [| ("one", 42L); ("two", 43L) |]
+}
+
+[<Fact>]
+let ``TaskSeq-zip throws on unequal lengths`` () = task {
+    let one = createDummyTaskSeq 10
+    let two = createDummyTaskSeq 11
+    let combined = TaskSeq.zip one two
+
+    fun () -> TaskSeq.toArrayAsync combined |> Task.ignore
+    |> should throwAsyncExact typeof<ArgumentException>
+}
+
+[<Fact>]
+let ``TaskSeq-zip can zip empty arrays`` () = task {
+    let combined = TaskSeq.zip TaskSeq.empty<int> TaskSeq.empty<string>
+    let! combined = TaskSeq.toArrayAsync combined
+    combined |> should be Empty
+    Array.isEmpty combined |> should be True
+}

--- a/src/FSharpy.TaskSeq/TaskSeq.fs
+++ b/src/FSharpy.TaskSeq/TaskSeq.fs
@@ -53,6 +53,7 @@ module TaskSeq =
             e.DisposeAsync().AsTask().Wait()
     }
 
+    // FIXME: incomplete and incorrect code!!!
     let toSeqOfTasks (taskSeq: taskSeq<'T>) = seq {
         let e = taskSeq.GetAsyncEnumerator(CancellationToken())
 

--- a/src/FSharpy.TaskSeq/TaskSeqInternal.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqInternal.fs
@@ -177,20 +177,23 @@ module internal TaskSeqInternal =
         let e2 = taskSequence2.GetAsyncEnumerator(CancellationToken())
         let mutable go = true
         let! step1 = e1.MoveNextAsync()
-        let! step2 = e1.MoveNextAsync()
+        let! step2 = e2.MoveNextAsync()
         go <- step1 && step2
 
         while go do
             yield e1.Current, e2.Current
             let! step1 = e1.MoveNextAsync()
-            let! step2 = e1.MoveNextAsync()
+            let! step2 = e2.MoveNextAsync()
+
+            if step1 <> step2 then
+                if step1 then
+                    invalidArg "taskSequence1" "The task sequences have different lengths."
+
+                if step2 then
+                    invalidArg "taskSequence2" "The task sequences have different lengths."
+
             go <- step1 && step2
 
-        if step1 then
-            invalidArg "taskSequence1" "The task sequences have different lengths."
-
-        if step2 then
-            invalidArg "taskSequence2" "The task sequences have different lengths."
     }
 
     let collect (binder: _ -> #IAsyncEnumerable<_>) (taskSequence: taskSeq<_>) = taskSeq {


### PR DESCRIPTION
## GOAL: `100%` coverage!!! ✅

That is: 100% coverage for the BL parts of the code: all of `TaskSeq.fs` and `TaskSeqInternal.fs`.

This adds missing tests for the following functions

```f#
TaskSeq.zip
TaskSeq.exactlyOne
TaskSeq.tryExactlyOne
TaskSeq.map*
TaskSeq.mapi*
TaskSeq.mapAsync
TaskSeq.mapiAsync
TaskSeq.iter*
TaskSeq.iteri*
TaskSeq.iterAsync
TaskSeq.iteriAsync
TaskSeq.empty*
TaskSeq.collect*
TaskSeq.collectSeq*
TaskSeq.collectAsync
TaskSeq.collectSeqAsync
TaskSeq.ofResizeArray
```

\* these had existing tests that I've improved a bit on, most notably, adding mutable-data tests

