### PR TITLE
Check resumable state machine MemberwiseClone setting incorrect state on multiple iterations

### DIFF
--- a/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
+++ b/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="TaskSeq.OfXXX.Tests.fs" />
     <Compile Include="TaskSeq.Tests.Other.fs" />
     <Compile Include="TaskSeq.Tests.CE.fs" />
+    <Compile Include="TaskSeq.StateTransitionBug.Tests.CE.fs" />
     <Compile Include="TaskSeq.PocTests.fs" />
     <Compile Include="TaskSeq.Realworld.fs" />
     <Compile Include="Program.fs" />

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -37,6 +37,18 @@ let ``TaskSeq-iter should go over all items`` () = task {
     sum |> should equal 55 // task-dummies started at 1
 }
 
+
+[<Fact>]
+let ``TaskSeq-iter multiple iterations over same sequence`` () = task {
+    let tq = createDummyTaskSeq 10
+    let mutable sum = 0
+    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+    sum |> should equal 220 // task-dummies started at 1
+}
+
 [<Fact>]
 let ``TaskSeq-iteriAsync should go over all items`` () = task {
     let tq = createDummyTaskSeq 10

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -78,16 +78,24 @@ let ``TaskSeq-mapAsync can map the same sequence multiple times`` () = task {
         TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
         >> TaskSeq.toSeqCachedAsync
 
-    let ts = createDummyTaskSeq 10
-    let! result1 = mapAndCache ts
-    let! result2 = mapAndCache ts
-    let! result3 = mapAndCache ts
-    let! result4 = mapAndCache ts
+    let ts = createDummyDirectTaskSeq 10
+
+    let! result1 =
+        printfn "starting first"
+        mapAndCache ts
+    //let! result3 = mapAndCache ts
+    //let! result4 = mapAndCache ts
 
     validateSequence result1
+
+    let! result2 =
+        printfn "starting second"
+        mapAndCache ts
+
     validateSequence result2
-    validateSequence result3
-    validateSequence result4
+    //validateSequence result3
+    //validateSequence result4
+    ()
 }
 
 [<Fact>]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -73,6 +73,24 @@ let ``TaskSeq-mapAsync maps in correct order`` () = task {
 }
 
 [<Fact>]
+let ``TaskSeq-mapAsync can map the same sequence multiple times`` () = task {
+    let mapAndCache =
+        TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
+        >> TaskSeq.toSeqCachedAsync
+
+    let ts = createDummyTaskSeq 10
+    let! result1 = mapAndCache ts
+    let! result2 = mapAndCache ts
+    let! result3 = mapAndCache ts
+    let! result4 = mapAndCache ts
+
+    validateSequence result1
+    validateSequence result2
+    validateSequence result3
+    validateSequence result4
+}
+
+[<Fact>]
 let ``TaskSeq-mapiAsync maps in correct order`` () = task {
     let! sq =
         createDummyTaskSeq 10

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
@@ -1,0 +1,155 @@
+module FSharpy.Tests.``State transition bug and InvalidState``
+
+open Xunit
+open FsUnit.Xunit
+open FsToolkit.ErrorHandling
+
+open FSharpy
+open System.Threading.Tasks
+open System.Diagnostics
+open System.Collections.Generic
+
+let getEmptyVariant variant : IAsyncEnumerable<int> =
+    match variant with
+    | "do" -> taskSeq { do ignore () }
+    | "do!" -> taskSeq { do! task { return () } } // TODO: this doesn't work with Task, only Task<unit>...
+    | "yield! (seq)" -> taskSeq { yield! Seq.empty<int> }
+    | "yield! (taskseq)" -> taskSeq { yield! taskSeq { do ignore () } }
+    | _ -> failwith "Uncovered variant of test"
+
+
+[<Fact>]
+let ``CE empty taskSeq with MoveNextAsync -- untyped`` () = task {
+    let tskSeq = taskSeq { do ignore () }
+
+    Assert.IsAssignableFrom<IAsyncEnumerable<obj>>(tskSeq)
+    |> ignore
+
+    let! noNext = tskSeq.GetAsyncEnumerator().MoveNextAsync()
+    noNext |> should be False
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE empty taskSeq with MoveNextAsync -- typed`` variant = task {
+    let tskSeq = getEmptyVariant variant
+
+    Assert.IsAssignableFrom<IAsyncEnumerable<int>>(tskSeq)
+    |> ignore
+
+    let! noNext = tskSeq.GetAsyncEnumerator().MoveNextAsync()
+    noNext |> should be False
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE  empty taskSeq, GetAsyncEnumerator multiple times`` variant = task {
+    let tskSeq = getEmptyVariant variant
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    ()
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE  empty taskSeq, GetAsyncEnumerator multiple times and then MoveNextAsync`` variant = task {
+    let tskSeq = getEmptyVariant variant
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    let! isNext = enumerator.MoveNextAsync()
+    ()
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync multiple times`` variant = task {
+    let tskSeq = getEmptyVariant variant
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    let! isNext = enumerator.MoveNextAsync()
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    let! isNext = enumerator.MoveNextAsync()
+    ()
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE  empty taskSeq, GetAsyncEnumerator + MoveNextAsync in a loop`` variant = task {
+    let tskSeq = getEmptyVariant variant
+
+    // let's get the enumerator a few times
+    for i in 0..10 do
+        printfn "Calling GetAsyncEnumerator for the #%i time" i
+        use enumerator = tskSeq.GetAsyncEnumerator()
+        let! isNext = enumerator.MoveNextAsync()
+        isNext |> should be False
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE taskSeq with two items, MoveNext once too far`` variant = task {
+    let tskSeq = taskSeq {
+        yield 1
+        yield 2
+    }
+
+    let enum = tskSeq.GetAsyncEnumerator()
+    let! isNext = enum.MoveNextAsync() // true
+    let! isNext = enum.MoveNextAsync() // true
+    let! isNext = enum.MoveNextAsync() // false
+    let! isNext = enum.MoveNextAsync() // error here, see
+    ()
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE taskSeq with two items, MoveNext too far`` variant = task {
+    let tskSeq = taskSeq {
+        yield 1
+        yield 2
+    }
+
+    // let's call MoveNext multiple times on an empty sequence
+    let enum = tskSeq.GetAsyncEnumerator()
+
+    for i in 0..10 do
+        printfn "Calling MoveNext for the #%i time" i
+        let! isNext = enum.MoveNextAsync()
+        //isNext |> should be False
+        ()
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE taskSeq with two items, multiple TaskSeq.map`` variant = task {
+    let tskSeq = taskSeq {
+        yield 1
+        yield 2
+    }
+
+    // let's call MoveNext multiple times on an empty sequence
+    let ts1 = tskSeq |> TaskSeq.map (fun i -> i + 1)
+    let result1 = TaskSeq.toArray ts1
+    let ts2 = ts1 |> TaskSeq.map (fun i -> i + 1)
+    let result2 = TaskSeq.toArray ts2
+    ()
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE taskSeq with two items, multiple TaskSeq.mapAsync`` variant = task {
+    let tskSeq = taskSeq {
+        yield 1
+        yield 2
+    }
+
+    // let's call MoveNext multiple times on an empty sequence
+    let ts1 = tskSeq |> TaskSeq.mapAsync (fun i -> task { return i + 1 })
+    let result1 = TaskSeq.toArray ts1
+    let ts2 = ts1 |> TaskSeq.mapAsync (fun i -> task { return i + 1 })
+    let result2 = TaskSeq.toArray ts2
+    ()
+}
+
+[<Fact>]
+let ``TaskSeq-toArray can be applied multiple times to the same sequence`` () =
+    let tq = createDummyTaskSeq 10
+    let (results1: _[]) = tq |> TaskSeq.toArray
+    let (results2: _[]) = tq |> TaskSeq.toArray
+    let (results3: _[]) = tq |> TaskSeq.toArray
+    let (results4: _[]) = tq |> TaskSeq.toArray
+    results1 |> should equal [| 1..10 |]
+    results2 |> should equal [| 1..10 |]
+    results3 |> should equal [| 1..10 |]
+    results4 |> should equal [| 1..10 |]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
@@ -1,13 +1,10 @@
-﻿module FSharpy.Tests.``taskSeq Computation Expression``
+module FSharpy.Tests.``taskSeq Computation Expression``
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
 open FSharpy
-open System.Threading.Tasks
-open System.Diagnostics
-
 
 [<Fact>]
 let ``CE taskSeq with several yield!`` () = task {

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
@@ -28,6 +28,19 @@ let ``TaskSeq-toArrayAsync should succeed`` () = task {
 }
 
 [<Fact>]
+let ``TaskSeq-toArrayAsync can be applied multiple times to the same sequence`` () = task {
+    let tq = createDummyTaskSeq 10
+    let! (results1: _[]) = tq |> TaskSeq.toArrayAsync
+    let! (results2: _[]) = tq |> TaskSeq.toArrayAsync
+    let! (results3: _[]) = tq |> TaskSeq.toArrayAsync
+    let! (results4: _[]) = tq |> TaskSeq.toArrayAsync
+    results1 |> should equal [| 1..10 |]
+    results2 |> should equal [| 1..10 |]
+    results3 |> should equal [| 1..10 |]
+    results4 |> should equal [| 1..10 |]
+}
+
+[<Fact>]
 let ``TaskSeq-toListAsync should succeed`` () = task {
     let tq = createDummyTaskSeq 10
     let! (results: list<_>) = tq |> TaskSeq.toListAsync

--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -379,11 +379,15 @@ type TaskSeqBuilder() =
                 let __stack_vtask = condition ()
 
                 if __stack_vtask.IsCompleted then
-                    printfn "Returning completed task (in while)"
+                    if verbose then
+                        printfn "Returning completed task (in while)"
+
                     __stack_condition_fin <- true
                     condition_res <- __stack_vtask.Result
                 else
-                    printfn "Awaiting non-completed task (in while)"
+                    if verbose then
+                        printfn "Awaiting non-completed task (in while)"
+
                     let task = __stack_vtask.AsTask()
                     let mutable awaiter = task.GetAwaiter()
                     // This will yield with __stack_fin = false

--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -153,23 +153,8 @@ and [<NoComparison; NoEquality>] TaskSeq<'Machine, 'T
 
         member ts.GetResult(token: int16) =
             match ts.hijack () with
-            | Some tg ->
-                if verbose then
-                    printfn "Getting result for token on 'Some' branch: %i" token
-
-                (tg :> IValueTaskSource<bool>).GetResult(token)
-            | None ->
-                try
-                    if verbose then
-                        printfn "Getting result for token on 'None' branch: %i" token
-
-                    ts.Machine.Data.promiseOfValueOrEnd.GetResult(token)
-                with e ->
-                    if verbose then
-                        printfn "Error for token: %i" token
-
-                    //reraise ()
-                    true
+            | Some tg -> (tg :> IValueTaskSource<bool>).GetResult(token)
+            | None -> ts.Machine.Data.promiseOfValueOrEnd.GetResult(token)
 
         member ts.OnCompleted(continuation, state, token, flags) =
             match ts.hijack () with


### PR DESCRIPTION
Fixes: #39 

If you create a `taskSeq` and iterate over it multiple times this should be safe (certainly, there could be a backing of a forward-only stream, but in essence, the wrapper for `IAsyncEnumerable` provided by `TaskSeq<...>` in `TaskBuilder.fs` should _on itself_ be safe to use multiple times).

* Add bunch of tests ✔️ (done: several minimal repro versions)
* Investigate ✔️ (done: cause is in `GetAsyncEnumerator`, the `else` path)

Not unimportant: the `TaskSeq` module utility functions that use hand-written enumeration code appear to be sound. The ones that use `taskSeq` under the hood are not. And when used with an `IAsyncEnumerable` created with `taskSeq`, they fail, because of this ☝️.