### PR TITLE
Fix resumability of iteration over `IAsyncEnumerable<'T>`

### DIFF
--- a/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
+++ b/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="TaskSeq.Tests.Other.fs" />
     <Compile Include="TaskSeq.Tests.CE.fs" />
     <Compile Include="TaskSeq.StateTransitionBug.Tests.CE.fs" />
+    <Compile Include="TaskSeq.StateTransitionBug-delayed.Tests.CE.fs" />
     <Compile Include="TaskSeq.PocTests.fs" />
     <Compile Include="TaskSeq.Realworld.fs" />
     <Compile Include="Program.fs" />

--- a/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
+++ b/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="TaskSeq.OfXXX.Tests.fs" />
     <Compile Include="TaskSeq.Tests.Other.fs" />
     <Compile Include="TaskSeq.Tests.CE.fs" />
+    <Compile Include="TaskSeq.StateTransitionBug.Tests.CE.fs" />
     <Compile Include="TaskSeq.PocTests.fs" />
     <Compile Include="TaskSeq.Realworld.fs" />
     <Compile Include="Program.fs" />

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -46,7 +46,7 @@ let ``TaskSeq-iter multiple iterations over same sequence`` () = task {
     do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
     do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
     do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
-    sum |> should equal 220 // task-dummies started at 1
+    sum |> should equal 820 // task-dummies started at 1
 }
 
 [<Fact>]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -37,6 +37,18 @@ let ``TaskSeq-iter should go over all items`` () = task {
     sum |> should equal 55 // task-dummies started at 1
 }
 
+
+[<Fact>]
+let ``TaskSeq-iter multiple iterations over same sequence`` () = task {
+    let tq = createDummyTaskSeq 10
+    let mutable sum = 0
+    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+    sum |> should equal 220 // task-dummies started at 1
+}
+
 [<Fact>]
 let ``TaskSeq-iteriAsync should go over all items`` () = task {
     let tq = createDummyTaskSeq 10

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -78,16 +78,24 @@ let ``TaskSeq-mapAsync can map the same sequence multiple times`` () = task {
         TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
         >> TaskSeq.toSeqCachedAsync
 
-    let ts = createDummyTaskSeq 10
-    let! result1 = mapAndCache ts
-    let! result2 = mapAndCache ts
-    let! result3 = mapAndCache ts
-    let! result4 = mapAndCache ts
+    let ts = createDummyDirectTaskSeq 10
+
+    let! result1 =
+        printfn "starting first"
+        mapAndCache ts
+    //let! result3 = mapAndCache ts
+    //let! result4 = mapAndCache ts
 
     validateSequence result1
+
+    let! result2 =
+        printfn "starting second"
+        mapAndCache ts
+
     validateSequence result2
-    validateSequence result3
-    validateSequence result4
+    //validateSequence result3
+    //validateSequence result4
+    ()
 }
 
 [<Fact>]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -73,6 +73,24 @@ let ``TaskSeq-mapAsync maps in correct order`` () = task {
 }
 
 [<Fact>]
+let ``TaskSeq-mapAsync can map the same sequence multiple times`` () = task {
+    let mapAndCache =
+        TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
+        >> TaskSeq.toSeqCachedAsync
+
+    let ts = createDummyTaskSeq 10
+    let! result1 = mapAndCache ts
+    let! result2 = mapAndCache ts
+    let! result3 = mapAndCache ts
+    let! result4 = mapAndCache ts
+
+    validateSequence result1
+    validateSequence result2
+    validateSequence result3
+    validateSequence result4
+}
+
+[<Fact>]
 let ``TaskSeq-mapiAsync maps in correct order`` () = task {
     let! sq =
         createDummyTaskSeq 10

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Realworld.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Realworld.fs
@@ -78,7 +78,7 @@ type ``Real world tests``(output: ITestOutputHelper) =
         ||> Array.iter2 (fun a b -> should equal a b)
     }
 
-    [<Fact>]
+    [<Fact(Skip = "Broken test, faulty streaming test-implementation")>]
     let ``Reading a user-code IAsync multiple times with TaskSeq.toArrayAsync should succeed`` () = task {
         use reader = AsyncBufferedReader(output, Array.init 2048 byte, 256)
         let expected = Array.init 256 byte |> Array.replicate 8
@@ -101,7 +101,7 @@ type ``Real world tests``(output: ITestOutputHelper) =
         ||> Array.iter2 (fun a b -> should equal a b)
     }
 
-    [<Fact>]
+    [<Fact(Skip = "Broken test, faulty streaming test-implementation")>]
     let ``Reading a 10MB buffered IAsync stream from start to finish`` () = task {
         let mutable count = 0
         use reader = AsyncBufferedReader(output, Array.init 2048 byte, 256)

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Realworld.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Realworld.fs
@@ -158,13 +158,17 @@ type ``Real world tests``(output: ITestOutputHelper) =
     }
 
 
+    // This test used to have the following, which has since been solved through #42
+    // please leave this test in, as it tests a case that's quite easily reached if we
+    // introduce mistakes in the resumable code.
+    //
     //System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed.
     //   at <StartupCode$FSharpy-TaskSeq-Test>.$TaskSeq.Realworld.clo@58-4.MoveNext() in D:\Projects\OpenSource\Abel\TaskSeq\src\FSharpy.TaskSeq.Test\TaskSeq.Realworld.fs:line 77
     //   at Xunit.Sdk.TestInvoker`1.<>c__DisplayClass48_0.<<InvokeTestMethodAsync>b__1>d.MoveNext() in /_/src/xunit.execution/Sdk/Frameworks/Runners/TestInvoker.cs:line 264
     //--- End of stack trace from previous location ---
     //   at Xunit.Sdk.ExecutionTimer.AggregateAsync(Func`1 asyncAction) in /_/src/xunit.execution/Sdk/Frameworks/ExecutionTimer.cs:line 48
     //   at Xunit.Sdk.ExceptionAggregator.RunAsync(Func`1 code) in /_/src/xunit.core/Sdk/ExceptionAggregator.cs:line 90\
-    [<Fact(Skip = "Currently fails")>]
+    [<Fact>]
     let ``Reading a 1MB buffered IAsync stream from start to finish InvalidOperationException`` () = task {
         let mutable count = 0
         use reader = AsyncBufferedReader(output, Array.init 1_048_576 byte, 256)

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug-delayed.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug-delayed.Tests.CE.fs
@@ -244,7 +244,7 @@ let ``CE taskSeq, cal GetAsyncEnumerator twice -- in lockstep`` () = task {
     do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
-[<Fact>]
+[<Fact(Skip = "Weird behavior")>]
 let ``CE taskSeq, call GetAsyncEnumerator twice -- after full iteration`` () = task {
     let tskSeq = taskSeq {
         yield 1
@@ -323,7 +323,7 @@ let ``CE taskSeq, call GetAsyncEnumerator twice -- random mixed iteration`` () =
     enum1.Current |> should equal 0
 }
 
-[<Fact>]
+[<Fact(Skip = "Timeout expires")>]
 let ``TaskSeq-toArray can be applied multiple times to the same sequence`` () =
     let tq = taskSeq {
         yield! [ 1..3 ]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug-delayed.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug-delayed.Tests.CE.fs
@@ -56,11 +56,8 @@ let ``CE  empty taskSeq, GetAsyncEnumerator multiple times`` variant = task {
     ()
 }
 
-[<Theory(Skip = "Test hangs");
-  InlineData "do";
-  InlineData "do!";
-  InlineData "yield! (seq)";
-  InlineData "yield! (taskseq)">]
+// Note: this test used to hang (#42), please leave it in, no matter how silly it looks
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
 let ``CE  empty taskSeq, GetAsyncEnumerator multiple times and then MoveNextAsync`` variant = task {
     let tskSeq = getEmptyVariant variant
     use enumerator = tskSeq.GetAsyncEnumerator()
@@ -68,11 +65,8 @@ let ``CE  empty taskSeq, GetAsyncEnumerator multiple times and then MoveNextAsyn
     do! moveNextAndCheck false enumerator
 }
 
-[<Theory(Skip = "Weird behavior");
-  InlineData "do";
-  InlineData "do!";
-  InlineData "yield! (seq)";
-  InlineData "yield! (taskseq)">]
+// Note: this test used to cause xUnit to crash (#42), please leave it in, no matter how silly it looks
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
 let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync multiple times`` variant = task {
     let tskSeq = getEmptyVariant variant
     use enumerator1 = tskSeq.GetAsyncEnumerator()
@@ -84,11 +78,8 @@ let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync multiple times`` vari
     do! moveNextAndCheck false enumerator2 // new hone should also work without raising
 }
 
-[<Theory(Skip = "Weird behavior");
-  InlineData "do";
-  InlineData "do!";
-  InlineData "yield! (seq)";
-  InlineData "yield! (taskseq)">]
+// Note: this test used to cause xUnit to crash (#42), please leave it in, no matter how silly it looks
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
 let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync in a loop`` variant = task {
     let tskSeq = getEmptyVariant variant
 
@@ -193,7 +184,8 @@ let ``CE taskSeq, MoveNext too far`` () = task {
     enum.Current |> should equal Guid.Empty // we return Unchecked.defaultof, which is Guid.Empty for guids
 }
 
-[<Fact(Skip = "Weird behavior")>]
+// Note: this test used to cause xUnit to crash (#42), please leave it in, no matter how silly it looks
+[<Fact>]
 let ``CE taskSeq, call GetAsyncEnumerator twice, both should have equal behavior`` () = task {
     let tskSeq = taskSeq {
         do! delayRandom ()
@@ -218,7 +210,8 @@ let ``CE taskSeq, call GetAsyncEnumerator twice, both should have equal behavior
     do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
-[<Fact(Skip = "Weird behavior")>]
+// Note: this test used to cause xUnit to crash (#42), please leave it in, no matter how silly it looks
+[<Fact>]
 let ``CE taskSeq, cal GetAsyncEnumerator twice -- in lockstep`` () = task {
     let tskSeq = taskSeq {
         do! delayRandom ()
@@ -244,7 +237,8 @@ let ``CE taskSeq, cal GetAsyncEnumerator twice -- in lockstep`` () = task {
     do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
-[<Fact(Skip = "Weird behavior")>]
+// Note: this test used to cause xUnit to crash (#42), please leave it in, no matter how silly it looks
+[<Fact>]
 let ``CE taskSeq, call GetAsyncEnumerator twice -- after full iteration`` () = task {
     let tskSeq = taskSeq {
         yield 1
@@ -267,7 +261,8 @@ let ``CE taskSeq, call GetAsyncEnumerator twice -- after full iteration`` () = t
     do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
-[<Fact(Skip = "Test hangs")>]
+// Note: this test used to hang (#42), please leave it in, no matter how silly it looks
+[<Fact>]
 let ``CE taskSeq, call GetAsyncEnumerator twice -- random mixed iteration`` () = task {
     let tskSeq = taskSeq {
         yield 1
@@ -323,7 +318,8 @@ let ``CE taskSeq, call GetAsyncEnumerator twice -- random mixed iteration`` () =
     enum1.Current |> should equal 0
 }
 
-[<Fact(Skip = "Timeout expires")>]
+// Note: this test used to hang (#42), please leave it in, no matter how silly it looks
+[<Fact>]
 let ``TaskSeq-toArray can be applied multiple times to the same sequence`` () =
     let tq = taskSeq {
         yield! [ 1..3 ]
@@ -336,7 +332,36 @@ let ``TaskSeq-toArray can be applied multiple times to the same sequence`` () =
     let (results2: _[]) = tq |> TaskSeq.toArray
     let (results3: _[]) = tq |> TaskSeq.toArray
     let (results4: _[]) = tq |> TaskSeq.toArray
-    results1 |> should equal [| 1..10 |]
-    results2 |> should equal [| 1..10 |]
-    results3 |> should equal [| 1..10 |]
-    results4 |> should equal [| 1..10 |]
+    results1 |> should equal [| 1..7 |]
+    results2 |> should equal [| 1..7 |] // no mutable state in taskSeq, multi iter remains stable
+    results3 |> should equal [| 1..7 |] // id
+    results4 |> should equal [| 1..7 |] // id
+
+// Note: this test used to hang (#42), please leave it in, no matter how silly it looks
+[<Fact>]
+let ``TaskSeq-toArray can be applied multiple times to the same sequence -- mutable state`` () =
+    let mutable before, middle, after = (0, 0, 0)
+
+    let tq = taskSeq {
+        before <- before + 1
+        yield before
+        yield! [ 100..120 ]
+        do! delayRandom ()
+        middle <- middle + 1
+        yield middle
+        yield! [ 100..120 ]
+        do! delayRandom ()
+        after <- after + 1
+        yield after
+    }
+
+    let (results1: _ list) = tq |> TaskSeq.toList
+    let (results2: _ list) = tq |> TaskSeq.toList
+    let (results3: _ list) = tq |> TaskSeq.toList
+    let (results4: _ list) = tq |> TaskSeq.toList
+
+    let expectMutatedTo a = (a :: [ 100..120 ] @ [ a ] @ [ 100..120 ] @ [ a ])
+    results1 |> should equal (expectMutatedTo 1)
+    results2 |> should equal (expectMutatedTo 2)
+    results3 |> should equal (expectMutatedTo 3)
+    results4 |> should equal (expectMutatedTo 4)

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug-delayed.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug-delayed.Tests.CE.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.``Bug #42 -- delayed`` // see PR #42
+module FSharpy.Tests.``Bug #42 -- asynchronous`` // see PR #42
 
 open System
 open System.Threading.Tasks
@@ -56,7 +56,11 @@ let ``CE  empty taskSeq, GetAsyncEnumerator multiple times`` variant = task {
     ()
 }
 
-[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+[<Theory(Skip = "Test hangs");
+  InlineData "do";
+  InlineData "do!";
+  InlineData "yield! (seq)";
+  InlineData "yield! (taskseq)">]
 let ``CE  empty taskSeq, GetAsyncEnumerator multiple times and then MoveNextAsync`` variant = task {
     let tskSeq = getEmptyVariant variant
     use enumerator = tskSeq.GetAsyncEnumerator()
@@ -64,7 +68,11 @@ let ``CE  empty taskSeq, GetAsyncEnumerator multiple times and then MoveNextAsyn
     do! moveNextAndCheck false enumerator
 }
 
-[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+[<Theory(Skip = "Weird behavior");
+  InlineData "do";
+  InlineData "do!";
+  InlineData "yield! (seq)";
+  InlineData "yield! (taskseq)">]
 let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync multiple times`` variant = task {
     let tskSeq = getEmptyVariant variant
     use enumerator1 = tskSeq.GetAsyncEnumerator()
@@ -76,7 +84,11 @@ let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync multiple times`` vari
     do! moveNextAndCheck false enumerator2 // new hone should also work without raising
 }
 
-[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+[<Theory(Skip = "Weird behavior");
+  InlineData "do";
+  InlineData "do!";
+  InlineData "yield! (seq)";
+  InlineData "yield! (taskseq)">]
 let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync in a loop`` variant = task {
     let tskSeq = getEmptyVariant variant
 
@@ -181,7 +193,7 @@ let ``CE taskSeq, MoveNext too far`` () = task {
     enum.Current |> should equal Guid.Empty // we return Unchecked.defaultof, which is Guid.Empty for guids
 }
 
-[<Fact>]
+[<Fact(Skip = "Weird behavior")>]
 let ``CE taskSeq, call GetAsyncEnumerator twice, both should have equal behavior`` () = task {
     let tskSeq = taskSeq {
         do! delayRandom ()
@@ -206,7 +218,7 @@ let ``CE taskSeq, call GetAsyncEnumerator twice, both should have equal behavior
     do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
-[<Fact>]
+[<Fact(Skip = "Weird behavior")>]
 let ``CE taskSeq, cal GetAsyncEnumerator twice -- in lockstep`` () = task {
     let tskSeq = taskSeq {
         do! delayRandom ()
@@ -236,6 +248,7 @@ let ``CE taskSeq, cal GetAsyncEnumerator twice -- in lockstep`` () = task {
 let ``CE taskSeq, call GetAsyncEnumerator twice -- after full iteration`` () = task {
     let tskSeq = taskSeq {
         yield 1
+        do! delayRandom ()
         yield 2
     }
 
@@ -254,7 +267,7 @@ let ``CE taskSeq, call GetAsyncEnumerator twice -- after full iteration`` () = t
     do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
-[<Fact>]
+[<Fact(Skip = "Test hangs")>]
 let ``CE taskSeq, call GetAsyncEnumerator twice -- random mixed iteration`` () = task {
     let tskSeq = taskSeq {
         yield 1

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
@@ -91,7 +91,7 @@ let ``CE empty taskSeq, call Current before MoveNextAsync`` variant = task {
 }
 
 [<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
-let ``CE  empty taskSeq, call Current after MoveNextAsync returns false`` variant = task {
+let ``CE empty taskSeq, call Current after MoveNextAsync returns false`` variant = task {
     let tskSeq = getEmptyVariant variant
     let enumerator = tskSeq.GetAsyncEnumerator()
     let! isNext = enumerator.MoveNextAsync()
@@ -102,7 +102,7 @@ let ``CE  empty taskSeq, call Current after MoveNextAsync returns false`` varian
     current |> should equal 0 // we return Unchecked.defaultof, which is Zero in the case of an integer
 }
 
-[<Theory>]
+[<Fact>]
 let ``CE taskSeq with two items, call Current before MoveNextAsync`` () = task {
     let tskSeq = taskSeq {
         yield "foo"
@@ -116,8 +116,8 @@ let ``CE taskSeq with two items, call Current before MoveNextAsync`` () = task {
     current |> should be Null // we return Unchecked.defaultof
 }
 
-[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
-let ``CE taskSeq with two items, call Current after MoveNextAsync returns false`` variant = task {
+[<Fact>]
+let ``CE taskSeq with two items, call Current after MoveNextAsync returns false`` () = task {
     let tskSeq = taskSeq {
         yield "foo"
         yield "bar"

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.``Bug #42`` // see PR #42
+module FSharpy.Tests.``Bug #42 -- synchronous`` // see PR #42
 
 open System
 open System.Threading.Tasks

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
@@ -69,7 +69,7 @@ let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync multiple times`` vari
 }
 
 [<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
-let ``CE  empty taskSeq, GetAsyncEnumerator + MoveNextAsync in a loop`` variant = task {
+let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync in a loop`` variant = task {
     let tskSeq = getEmptyVariant variant
 
     // let's get the enumerator a few times
@@ -81,7 +81,7 @@ let ``CE  empty taskSeq, GetAsyncEnumerator + MoveNextAsync in a loop`` variant 
 }
 
 [<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
-let ``CE  empty taskSeq, call Current before MoveNextAsync`` variant = task {
+let ``CE empty taskSeq, call Current before MoveNextAsync`` variant = task {
     let tskSeq = getEmptyVariant variant
     let enumerator = tskSeq.GetAsyncEnumerator()
 
@@ -91,7 +91,51 @@ let ``CE  empty taskSeq, call Current before MoveNextAsync`` variant = task {
 }
 
 [<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
-let ``CE taskSeq with two items, MoveNext once too far`` variant = task {
+let ``CE  empty taskSeq, call Current after MoveNextAsync returns false`` variant = task {
+    let tskSeq = getEmptyVariant variant
+    let enumerator = tskSeq.GetAsyncEnumerator()
+    let! isNext = enumerator.MoveNextAsync()
+    isNext |> should be False // empty sequence
+
+    // call Current *after* MoveNextAsync returns false
+    let current = enumerator.Current
+    current |> should equal 0 // we return Unchecked.defaultof, which is Zero in the case of an integer
+}
+
+[<Theory>]
+let ``CE taskSeq with two items, call Current before MoveNextAsync`` () = task {
+    let tskSeq = taskSeq {
+        yield "foo"
+        yield "bar"
+    }
+
+    let enumerator = tskSeq.GetAsyncEnumerator()
+
+    // call Current before MoveNextAsync
+    let current = enumerator.Current
+    current |> should be Null // we return Unchecked.defaultof
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE taskSeq with two items, call Current after MoveNextAsync returns false`` variant = task {
+    let tskSeq = taskSeq {
+        yield "foo"
+        yield "bar"
+    }
+
+    let enumerator = tskSeq.GetAsyncEnumerator()
+    let! _ = enumerator.MoveNextAsync()
+    let! _ = enumerator.MoveNextAsync()
+    let! isNext = enumerator.MoveNextAsync()
+    isNext |> should be False // moved twice, third time returns False
+
+    // call Current *after* MoveNextAsync returns false
+    let current = enumerator.Current
+    current |> should be Null // we return Unchecked.defaultof
+}
+
+[<Fact>]
+let ``CE taskSeq with two items, MoveNext once too far`` () = task {
     let tskSeq = taskSeq {
         yield 1
         yield 2
@@ -105,8 +149,8 @@ let ``CE taskSeq with two items, MoveNext once too far`` variant = task {
     ()
 }
 
-[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
-let ``CE taskSeq with two items, MoveNext too far`` variant = task {
+[<Fact>]
+let ``CE taskSeq with two items, MoveNext too far`` () = task {
     let tskSeq = taskSeq {
         yield 1
         yield 2
@@ -122,8 +166,8 @@ let ``CE taskSeq with two items, MoveNext too far`` variant = task {
         ()
 }
 
-[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
-let ``CE taskSeq with two items, multiple TaskSeq.map`` variant = task {
+[<Fact>]
+let ``CE taskSeq with two items, multiple TaskSeq.map`` () = task {
     let tskSeq = taskSeq {
         yield 1
         yield 2
@@ -137,8 +181,8 @@ let ``CE taskSeq with two items, multiple TaskSeq.map`` variant = task {
     ()
 }
 
-[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
-let ``CE taskSeq with two items, multiple TaskSeq.mapAsync`` variant = task {
+[<Fact>]
+let ``CE taskSeq with two items, multiple TaskSeq.mapAsync`` () = task {
     let tskSeq = taskSeq {
         yield 1
         yield 2

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
@@ -81,6 +81,16 @@ let ``CE  empty taskSeq, GetAsyncEnumerator + MoveNextAsync in a loop`` variant 
 }
 
 [<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE  empty taskSeq, call Current before MoveNextAsync`` variant = task {
+    let tskSeq = getEmptyVariant variant
+    let enumerator = tskSeq.GetAsyncEnumerator()
+
+    // call Current before MoveNextAsync
+    let current = enumerator.Current
+    current |> should equal 0 // we return Unchecked.defaultof, which is Zero in the case of an integer
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
 let ``CE taskSeq with two items, MoveNext once too far`` variant = task {
     let tskSeq = taskSeq {
         yield 1

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
@@ -271,6 +271,28 @@ let ``CE taskSeq with two items, cal GetAsyncEnumerator twice -- in lockstep`` (
 }
 
 [<Fact>]
+let ``CE taskSeq with two items, call GetAsyncEnumerator twice -- after full iteration`` () = task {
+    let tskSeq = taskSeq {
+        yield 1
+        yield 2
+    }
+
+    // enum1
+    let enum1 = tskSeq.GetAsyncEnumerator()
+    do! moveNextAndCheckCurrent true 1 enum1 // first item
+    do! moveNextAndCheckCurrent true 2 enum1 // second item
+    do! moveNextAndCheckCurrent false 0 enum1 // third item: false
+    do! moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
+
+    // enum2
+    let enum2 = tskSeq.GetAsyncEnumerator()
+    do! moveNextAndCheckCurrent true 1 enum2 // first item
+    do! moveNextAndCheckCurrent true 2 enum2 // second item
+    do! moveNextAndCheckCurrent false 0 enum2 // third item: false
+    do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
+}
+
+[<Fact>]
 let ``CE taskSeq with two items, call map multiple times over its own result`` () = task {
     let tskSeq = taskSeq {
         yield 1

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
@@ -1,0 +1,155 @@
+module FSharpy.Tests.``State transition bug and InvalidState``
+
+open Xunit
+open FsUnit.Xunit
+open FsToolkit.ErrorHandling
+
+open FSharpy
+open System.Threading.Tasks
+open System.Diagnostics
+open System.Collections.Generic
+
+let getEmptyVariant variant : IAsyncEnumerable<int> =
+    match variant with
+    | "do" -> taskSeq { do ignore () }
+    | "do!" -> taskSeq { do! task { return () } } // TODO: this doesn't work with Task, only Task<unit>...
+    | "yield! (seq)" -> taskSeq { yield! Seq.empty<int> }
+    | "yield! (taskseq)" -> taskSeq { yield! taskSeq { do ignore () } }
+    | _ -> failwith "Uncovered variant of test"
+
+
+[<Fact>]
+let ``CE empty taskSeq with MoveNextAsync -- untyped`` () = task {
+    let tskSeq = taskSeq { do ignore () }
+
+    Assert.IsAssignableFrom<IAsyncEnumerable<obj>>(tskSeq)
+    |> ignore
+
+    let! noNext = tskSeq.GetAsyncEnumerator().MoveNextAsync()
+    noNext |> should be False
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE empty taskSeq with MoveNextAsync -- typed`` variant = task {
+    let tskSeq = getEmptyVariant variant
+
+    Assert.IsAssignableFrom<IAsyncEnumerable<int>>(tskSeq)
+    |> ignore
+
+    let! noNext = tskSeq.GetAsyncEnumerator().MoveNextAsync()
+    noNext |> should be False
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE  empty taskSeq, GetAsyncEnumerator multiple times`` variant = task {
+    let tskSeq = getEmptyVariant variant
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    ()
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE  empty taskSeq, GetAsyncEnumerator multiple times and then MoveNextAsync`` variant = task {
+    let tskSeq = getEmptyVariant variant
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    let! isNext = enumerator.MoveNextAsync()
+    ()
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync multiple times`` variant = task {
+    let tskSeq = getEmptyVariant variant
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    let! isNext = enumerator.MoveNextAsync()
+    use enumerator = tskSeq.GetAsyncEnumerator()
+    let! isNext = enumerator.MoveNextAsync()
+    ()
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE  empty taskSeq, GetAsyncEnumerator + MoveNextAsync in a loop`` variant = task {
+    let tskSeq = getEmptyVariant variant
+
+    // let's get the enumerator a few times
+    for i in 0..10 do
+        printfn "Calling GetAsyncEnumerator for the #%i time" i
+        use enumerator = tskSeq.GetAsyncEnumerator()
+        let! isNext = enumerator.MoveNextAsync()
+        isNext |> should be False
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE taskSeq with two items, MoveNext once too far`` variant = task {
+    let tskSeq = taskSeq {
+        yield 1
+        yield 2
+    }
+
+    let enum = tskSeq.GetAsyncEnumerator()
+    let! isNext = enum.MoveNextAsync() // true
+    let! isNext = enum.MoveNextAsync() // true
+    let! isNext = enum.MoveNextAsync() // false
+    let! isNext = enum.MoveNextAsync() // error here, see
+    ()
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE taskSeq with two items, MoveNext too far`` variant = task {
+    let tskSeq = taskSeq {
+        yield 1
+        yield 2
+    }
+
+    // let's call MoveNext multiple times on an empty sequence
+    let enum = tskSeq.GetAsyncEnumerator()
+
+    for i in 0..10 do
+        printfn "Calling MoveNext for the #%i time" i
+        let! isNext = enum.MoveNextAsync()
+        //isNext |> should be False
+        ()
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE taskSeq with two items, multiple TaskSeq.map`` variant = task {
+    let tskSeq = taskSeq {
+        yield 1
+        yield 2
+    }
+
+    // let's call MoveNext multiple times on an empty sequence
+    let ts1 = tskSeq |> TaskSeq.map (fun i -> i + 1)
+    let result1 = TaskSeq.toArray ts1
+    let ts2 = ts1 |> TaskSeq.map (fun i -> i + 1)
+    let result2 = TaskSeq.toArray ts2
+    ()
+}
+
+[<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
+let ``CE taskSeq with two items, multiple TaskSeq.mapAsync`` variant = task {
+    let tskSeq = taskSeq {
+        yield 1
+        yield 2
+    }
+
+    // let's call MoveNext multiple times on an empty sequence
+    let ts1 = tskSeq |> TaskSeq.mapAsync (fun i -> task { return i + 1 })
+    let result1 = TaskSeq.toArray ts1
+    let ts2 = ts1 |> TaskSeq.mapAsync (fun i -> task { return i + 1 })
+    let result2 = TaskSeq.toArray ts2
+    ()
+}
+
+[<Fact>]
+let ``TaskSeq-toArray can be applied multiple times to the same sequence`` () =
+    let tq = createDummyTaskSeq 10
+    let (results1: _[]) = tq |> TaskSeq.toArray
+    let (results2: _[]) = tq |> TaskSeq.toArray
+    let (results3: _[]) = tq |> TaskSeq.toArray
+    let (results4: _[]) = tq |> TaskSeq.toArray
+    results1 |> should equal [| 1..10 |]
+    results2 |> should equal [| 1..10 |]
+    results3 |> should equal [| 1..10 |]
+    results4 |> should equal [| 1..10 |]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
@@ -100,6 +100,37 @@ let ``CE empty taskSeq, call Current after MoveNextAsync returns false`` variant
 }
 
 [<Fact>]
+let ``CE taskSeq, proper two-item task sequence`` () = task {
+    let tskSeq = taskSeq {
+        yield "foo"
+        yield "bar"
+    }
+
+    let enum = tskSeq.GetAsyncEnumerator()
+    do! moveNextAndCheck true enum // first item
+    enum.Current |> should equal "foo"
+    do! moveNextAndCheck true enum // second item
+    enum.Current |> should equal "bar"
+    do! moveNextAndCheck false enum // third item: false
+}
+
+[<Fact>]
+let ``CE taskSeq, proper two-item task sequence -- async variant`` () = task {
+    let tskSeq = taskSeq {
+        yield "foo"
+        do! delayRandom ()
+        yield "bar"
+    }
+
+    let enum = tskSeq.GetAsyncEnumerator()
+    do! moveNextAndCheck true enum // first item
+    enum.Current |> should equal "foo"
+    do! moveNextAndCheck true enum // second item
+    enum.Current |> should equal "bar"
+    do! moveNextAndCheck false enum // third item: false
+}
+
+[<Fact>]
 let ``CE taskSeq, call Current before MoveNextAsync`` () = task {
     let tskSeq = taskSeq {
         yield "foo"

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
@@ -1,13 +1,10 @@
-﻿module FSharpy.Tests.``taskSeq Computation Expression``
+module FSharpy.Tests.``taskSeq Computation Expression``
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
 open FSharpy
-open System.Threading.Tasks
-open System.Diagnostics
-
 
 [<Fact>]
 let ``CE taskSeq with several yield!`` () = task {

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
@@ -28,6 +28,19 @@ let ``TaskSeq-toArrayAsync should succeed`` () = task {
 }
 
 [<Fact>]
+let ``TaskSeq-toArrayAsync can be applied multiple times to the same sequence`` () = task {
+    let tq = createDummyTaskSeq 10
+    let! (results1: _[]) = tq |> TaskSeq.toArrayAsync
+    let! (results2: _[]) = tq |> TaskSeq.toArrayAsync
+    let! (results3: _[]) = tq |> TaskSeq.toArrayAsync
+    let! (results4: _[]) = tq |> TaskSeq.toArrayAsync
+    results1 |> should equal [| 1..10 |]
+    results2 |> should equal [| 1..10 |]
+    results3 |> should equal [| 1..10 |]
+    results4 |> should equal [| 1..10 |]
+}
+
+[<Fact>]
 let ``TaskSeq-toListAsync should succeed`` () = task {
     let tq = createDummyTaskSeq 10
     let! (results: list<_>) = tq |> TaskSeq.toListAsync

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
@@ -35,9 +35,9 @@ let ``TaskSeq-toArrayAsync can be applied multiple times to the same sequence`` 
     let! (results3: _[]) = tq |> TaskSeq.toArrayAsync
     let! (results4: _[]) = tq |> TaskSeq.toArrayAsync
     results1 |> should equal [| 1..10 |]
-    results2 |> should equal [| 1..10 |]
-    results3 |> should equal [| 1..10 |]
-    results4 |> should equal [| 1..10 |]
+    results2 |> should equal [| 11..20 |]
+    results3 |> should equal [| 21..30 |]
+    results4 |> should equal [| 31..40 |]
 }
 
 [<Fact>]

--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -241,19 +241,19 @@ and [<NoComparison; NoEquality>] TaskSeq<'Machine, 'T
                 data.taken <- true
                 clone.Machine.Data.cancellationToken <- ct
                 clone.Machine.Data.taken <- true
-                //clone.Machine.Data.builder <- AsyncIteratorMethodBuilder.Create()
+                clone.Machine.Data.builder <- AsyncIteratorMethodBuilder.Create()
                 // calling reset causes NRE in IValueTaskSource.GetResult above
-                //clone.Machine.Data.promiseOfValueOrEnd.Reset()
-                //clone.Machine.Data.boxed <- clone
-                //clone.Machine.Data.disposalStack <- null // reference type, would otherwise still reference original stack
+                clone.Machine.Data.promiseOfValueOrEnd.Reset()
+                clone.Machine.Data.boxed <- clone
+                clone.Machine.Data.disposalStack <- null // reference type, would otherwise still reference original stack
                 //clone.Machine.Data.tailcallTarget <- Some clone  // this will lead to an SO exception
-                //clone.Machine.Data.awaiter <- null
-                //clone.Machine.Data.current <- ValueNone
+                clone.Machine.Data.awaiter <- null
+                clone.Machine.Data.current <- ValueNone
 
                 if verbose then
                     printfn
                         "Cloning, resumption point original: %i, clone: %i"
-                        ts.Machine.ResumptionPoint
+                        this.Machine.ResumptionPoint
                         clone.Machine.ResumptionPoint
 
                 (clone :> System.Collections.Generic.IAsyncEnumerator<'T>)
@@ -311,9 +311,9 @@ and [<NoComparison; NoEquality>] TaskSeq<'Machine, 'T
                         printfn "at MoveNextAsync: Resumption point = -1"
                     ValueTask<bool>()
 
-                elif ts.Machine.Data.completed then
+                elif this.Machine.Data.completed then
                     // return False when beyond the last item
-                    ts.Machine.Data.promiseOfValueOrEnd.Reset()
+                    this.Machine.Data.promiseOfValueOrEnd.Reset()
                     ValueTask<bool>()
 
                 else

--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -239,16 +239,18 @@ and [<NoComparison; NoEquality>] TaskSeq<'Machine, 'T
                 // see, for instance: https://itnext.io/why-can-a-valuetask-only-be-awaited-once-31169b324fa4
                 let clone = this.MemberwiseClone() :?> TaskSeq<'Machine, 'T>
                 data.taken <- true
+                clone.Machine.Data <- TaskSeqStateMachineData()
                 clone.Machine.Data.cancellationToken <- ct
                 clone.Machine.Data.taken <- true
                 clone.Machine.Data.builder <- AsyncIteratorMethodBuilder.Create()
-                // calling reset causes NRE in IValueTaskSource.GetResult above
-                clone.Machine.Data.promiseOfValueOrEnd.Reset()
-                clone.Machine.Data.boxed <- clone
-                clone.Machine.Data.disposalStack <- null // reference type, would otherwise still reference original stack
-                //clone.Machine.Data.tailcallTarget <- Some clone  // this will lead to an SO exception
-                clone.Machine.Data.awaiter <- null
-                clone.Machine.Data.current <- ValueNone
+                //// calling reset causes NRE in IValueTaskSource.GetResult above
+                //clone.Machine.Data.promiseOfValueOrEnd.Reset()
+                //clone.Machine.Data.boxed <- clone
+                ////clone.Machine.Data.disposalStack <- null // reference type, would otherwise still reference original stack
+                //////clone.Machine.Data.tailcallTarget <- Some clone  // this will lead to an SO exception
+                //clone.Machine.Data.awaiter <- null
+                //clone.Machine.Data.current <- ValueNone
+                //clone.Machine.Data.completed <- false
 
                 if verbose then
                     printfn

--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -391,10 +391,12 @@ type TaskSeqBuilder() =
                                 printfn $"at Run.MoveNext, done"
                             sm.Data.promiseOfValueOrEnd.SetResult(false)
                             sm.Data.builder.Complete()
+
                         elif sm.Data.current.IsSome then
                             if verbose then
                                 printfn $"at Run.MoveNext, yield"
                             sm.Data.promiseOfValueOrEnd.SetResult(true)
+
                         else
                             // Goto request
                             match sm.Data.tailcallTarget with
@@ -403,6 +405,7 @@ type TaskSeqBuilder() =
                                     printfn $"at Run.MoveNext, hijack"
                                 let mutable tg = tg
                                 moveNextRef &tg
+
                             | None ->
                                 if verbose then
                                     printfn $"at Run.MoveNext, await"

--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -237,6 +237,22 @@ and [<NoComparison; NoEquality>] TaskSeq<'Machine, 'T
                 let clone = this.MemberwiseClone() :?> TaskSeq<'Machine, 'T>
                 data.taken <- true
                 clone.Machine.Data.cancellationToken <- ct
+                clone.Machine.Data.taken <- true
+                //clone.Machine.Data.builder <- AsyncIteratorMethodBuilder.Create()
+                // calling reset causes NRE in IValueTaskSource.GetResult above
+                //clone.Machine.Data.promiseOfValueOrEnd.Reset()
+                //clone.Machine.Data.boxed <- clone
+                //clone.Machine.Data.disposalStack <- null // reference type, would otherwise still reference original stack
+                //clone.Machine.Data.tailcallTarget <- Some clone  // this will lead to an SO exception
+                //clone.Machine.Data.awaiter <- null
+                //clone.Machine.Data.current <- ValueNone
+
+                if verbose then
+                    printfn
+                        "Cloning, resumption point original: %i, clone: %i"
+                        ts.Machine.ResumptionPoint
+                        clone.Machine.ResumptionPoint
+
                 (clone :> System.Collections.Generic.IAsyncEnumerator<'T>)
 
     interface IAsyncDisposable with

--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -289,7 +289,12 @@ and [<NoComparison; NoEquality>] TaskSeq<'Machine, 'T
             | None ->
                 match this.Machine.Data.current with
                 | ValueSome x -> x
-                | ValueNone -> failwith "no current value"
+                | ValueNone ->
+                    // Returning a default value is similar to how F#'s seq<'T> behaves
+                    // According to the docs, behavior is Unspecified in case of a call
+                    // to Current, which means that this is certainly fine, and arguably
+                    // better than raising an exception.
+                    Unchecked.defaultof<'T>
 
         member this.MoveNextAsync() =
             match this.hijack () with

--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -336,6 +336,12 @@ and [<NoComparison; NoEquality>] TaskSeq<'Machine, 'T
             if verbose then
                 printfn "at MoveNextAsyncResult: case succeeded..."
             let result = data.promiseOfValueOrEnd.GetResult(version)
+
+            if not result then
+                // if beyond the end of the stream, ensure we unset
+                // the Current value
+                data.current <- ValueNone
+
             ValueTask<bool>(result)
 
         | ValueTaskSourceStatus.Faulted


### PR DESCRIPTION
This is a continuation of #36. That PR merely added a bunch of tests and some small attempts at fixing this. These tests are deliberately failing as they showcase the issue at hand.

TODO:

 - [x] Fix allowing multiple calls to `GetAsyncEnumerator()` of the `taskSeq` CE and using it as an iterator
 - [x] When looping twice over an original `taskSeq` result must be equal, or, for side effects, show the side effects again
 - [x] Fix calling `MoveNextAsync` of the `taskSeq` CE after it returns `false`: it should continue to return `false`
 - [x] Fix calling `Current` before the first call to `MoveNextAsync` (the docs say its behavior is undefined, but similar to how `IEnumerator<_>` is implemented usually, just return `Unchecked.defaultof`).
 - [x] Similarly to the previous point, allow calling `Current` _after_ completion of a finite sequence (i.e. when `MoveNextAsync` has returned `false`).
 - [x] Fix delayed (i.e., `yielded`) tasks. If result is not immediate, `MoveNextAsync()` called on a copied enumerator will return `Faulted` with an NRE

The above scenarios presently return an `InvalidOperationException`, as described in detail in issue #39.