### PR TITLE
Set verbose=false

### DIFF
--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -15,7 +15,7 @@ open FSharp.Core.CompilerServices.StateMachineHelpers
 
 [<AutoOpen>]
 module Internal = // cannot be marked with 'internal' scope
-    let verbose = true
+    let verbose = false
 
     let inline MoveNext (x: byref<'T> when 'T :> IAsyncStateMachine) = x.MoveNext()
 


### PR DESCRIPTION
Yeah, this flag is just for getting good traces while testing. Should be `false` in the `main` branch (and should probably take an environment variable of sorts instead).