### PR TITLE
Small refactor, cherry-picking non-functional changes from #42 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+*.ncrunchproject


### PR DESCRIPTION
Picking up changes from #42 that aren't functional changes, to make it easier to diff that branch with `main`, and to be able to disable/enable changes that cause the NRE in delayed-async shadow-enumerated sequences.