### PR TITLE
Improve GetAsyncEnumerator, move inheritance of IAsyncDisposable

### DIFF
--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug-delayed.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug-delayed.Tests.CE.fs
@@ -60,7 +60,10 @@ let ``CE  empty taskSeq, GetAsyncEnumerator multiple times`` variant = task {
 [<Theory; InlineData "do"; InlineData "do!"; InlineData "yield! (seq)"; InlineData "yield! (taskseq)">]
 let ``CE  empty taskSeq, GetAsyncEnumerator multiple times and then MoveNextAsync`` variant = task {
     let tskSeq = getEmptyVariant variant
-    use enumerator = tskSeq.GetAsyncEnumerator()
+    use _ = tskSeq.GetAsyncEnumerator()
+    use _ = tskSeq.GetAsyncEnumerator()
+    use _ = tskSeq.GetAsyncEnumerator()
+    use _ = tskSeq.GetAsyncEnumerator()
     use enumerator = tskSeq.GetAsyncEnumerator()
     do! moveNextAndCheck false enumerator
 }
@@ -75,7 +78,7 @@ let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync multiple times`` vari
     // getting the enumerator again
     use enumerator2 = tskSeq.GetAsyncEnumerator()
     do! moveNextAndCheck false enumerator1 // original should still work without raising
-    do! moveNextAndCheck false enumerator2 // new hone should also work without raising
+    do! moveNextAndCheck false enumerator2 // new one should also work without raising
 }
 
 // Note: this test used to cause xUnit to crash (#42), please leave it in, no matter how silly it looks

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
@@ -57,20 +57,20 @@ let ``CE taskSeq with nested yield!`` () = task {
 
 [<Fact>]
 let ``CE taskSeq with nested deeply yield! perf test 8521 nested tasks`` () = task {
-    let control = seq {
+    let expected = seq {
         yield! [ 1..10 ]
-
-        // original:
         yield! Seq.concat <| Seq.init 4251 (fun _ -> [ 1; 2 ])
-    //yield! Seq.concat <| Seq.init 120 (fun _ -> [ 1; 2 ])
     }
 
     let createTasks = createDummyTaskSeqWith 1L<µs> 10L<µs>
-    // FIXME: it appears that deeply nesting adds to performance degradation, need to benchmark/profile this
-    // probably cause: since this is *fast* with DirectTask, the reason is likely the way the Task.Delay causes
+    //
+    // NOTES: it appears that deeply nesting adds to performance degradation, need to benchmark/profile this
+    // probable cause: since this is *fast* with DirectTask, the reason is likely the way the Task.Delay causes
     // *many* subtasks to be delayed, resulting in exponential delay. Reason: max accuracy of Delay is about 15ms (!)
-
+    //
     // RESOLUTION: seems to have been caused by erratic Task.Delay which has only a 15ms resolution
+    //
+
     let tskSeq = taskSeq {
         yield! createTasks 10
 
@@ -107,7 +107,7 @@ let ``CE taskSeq with nested deeply yield! perf test 8521 nested tasks`` () = ta
 
     let! data = tskSeq |> TaskSeq.toListAsync
     data |> List.length |> should equal 8512
-    data |> should equal (List.ofSeq control)
+    data |> should equal (List.ofSeq expected) // cannot compare seq this way, so, List.ofSeq it is
 }
 
 [<Fact>]

--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -263,8 +263,9 @@ and [<NoComparison; NoEquality>] TaskSeq<'Machine, 'T
                 //
                 // Solution: we shadow the initial machine, which we then re-assign here:
                 //
-                let clone = this.MemberwiseClone() :?> TaskSeq<'Machine, 'T>
-                clone._machine <- clone._initialMachine
+                let clone = TaskSeq<'Machine, 'T>() // we used MemberwiseClone, TODO: test difference in perf, but this should be faster
+                clone._machine <- this._initialMachine
+                clone._initialMachine <- this._initialMachine // TODO: proof with a test that this is necessary: probably not
                 clone.InitMachineData(ct, &clone._machine)
                 clone
 


### PR DESCRIPTION
After the struggle with #42, some cleanup is needed, and some refactoring. Also, a few functional changes:

 - [x] `IAsyncEnumerable` itself should not implement `IAsyncDisposable`, instead, only `IAsyncEnumerator` should implement that, by default, because it already inherits from that interface. This change prevents accidental `use x = myTaskSeq` code, which we really should prevent.
    _Note: it is unlikely this would happen in practice, as we strictly return `IAsyncEnumerable<'T>`, however, someone creative could cast and succeed. Plus, it just doesn't make sense in the current implementation._
 - [x] Improve `GetAsyncEnumerator()`. Only initialize `TaskSeqStateMachineData`  when needed. That means, we won't initialize it anymore directly in the `AfterCode<_, _>` section.
 - [x] Add an `InitEnumerator` function, as after the previous change, we'll need to initialize from `ReturnFrom` as well, as `Data` member can now be `null`.