### PR TITLE
Improve data variety for data-driven tests (immutable, vs mutable, vs thread-yield, vs hot-delayed) plus massive refactoring

### DIFF
--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas": {
+      "version": "5.0.6",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/src/FSharpy.TaskSeq.Test/Program.fs
+++ b/src/FSharpy.TaskSeq.Test/Program.fs
@@ -1,1 +1,3 @@
-module Program = let [<EntryPoint>] main _ = 0
+module Program =
+    [<EntryPoint>]
+    let main _ = 0

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
@@ -32,7 +32,7 @@ let ``TaskSeq-chooseAsync on an empty sequence`` () = task {
 [<Fact>]
 let ``TaskSeq-choose can convert and filter`` () = task {
     let! alphabet =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.choose (fun number -> if number <= 26 then Some(char number + '@') else None)
         |> TaskSeq.toArrayAsync
 
@@ -42,7 +42,7 @@ let ``TaskSeq-choose can convert and filter`` () = task {
 [<Fact>]
 let ``TaskSeq-chooseAsync can convert and filter`` () = task {
     let! alphabet =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.chooseAsync (fun number -> task { return if number <= 26 then Some(char number + '@') else None })
         |> TaskSeq.toArrayAsync
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
@@ -15,7 +15,7 @@ let validateSequence sequence =
 [<Fact>]
 let ``TaskSeq-collect operates in correct order`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.collect (fun item -> taskSeq {
             yield char (item + 64)
             yield char (item + 65)
@@ -28,7 +28,7 @@ let ``TaskSeq-collect operates in correct order`` () = task {
 [<Fact>]
 let ``TaskSeq-collectAsync operates in correct order`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.collectAsync (fun item -> task {
             return taskSeq {
                 yield char (item + 64)
@@ -43,7 +43,7 @@ let ``TaskSeq-collectAsync operates in correct order`` () = task {
 [<Fact>]
 let ``TaskSeq-collectSeq operates in correct order`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.collectSeq (fun item -> seq {
             yield char (item + 64)
             yield char (item + 65)
@@ -56,7 +56,7 @@ let ``TaskSeq-collectSeq operates in correct order`` () = task {
 [<Fact>]
 let ``TaskSeq-collectSeq with arrays operates in correct order`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.collectSeq (fun item -> [| char (item + 64); char (item + 65) |])
         |> TaskSeq.toArrayAsync
 
@@ -66,7 +66,7 @@ let ``TaskSeq-collectSeq with arrays operates in correct order`` () = task {
 [<Fact>]
 let ``TaskSeq-collectSeqAsync operates in correct order`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.collectSeqAsync (fun item -> task {
             return seq {
                 yield char (item + 64)
@@ -81,7 +81,7 @@ let ``TaskSeq-collectSeqAsync operates in correct order`` () = task {
 [<Fact>]
 let ``TaskSeq-collectSeqAsync with arrays operates in correct order`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.collectSeqAsync (fun item -> task { return [| char (item + 64); char (item + 65) |] })
         |> TaskSeq.toArrayAsync
 
@@ -91,7 +91,7 @@ let ``TaskSeq-collectSeqAsync with arrays operates in correct order`` () = task 
 [<Fact>]
 let ``TaskSeq-collect with empty task sequences`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.collect (fun _ -> TaskSeq.ofSeq Seq.empty)
         |> TaskSeq.toSeqCachedAsync
 
@@ -101,7 +101,7 @@ let ``TaskSeq-collect with empty task sequences`` () = task {
 [<Fact>]
 let ``TaskSeq-collectAsync with empty task sequences`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.collectAsync (fun _ -> task { return TaskSeq.empty<string> })
         |> TaskSeq.toSeqCachedAsync
 
@@ -111,7 +111,7 @@ let ``TaskSeq-collectAsync with empty task sequences`` () = task {
 [<Fact>]
 let ``TaskSeq-collectSeq with empty sequences`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.collectSeq (fun _ -> Seq.empty<int>)
         |> TaskSeq.toSeqCachedAsync
 
@@ -121,7 +121,7 @@ let ``TaskSeq-collectSeq with empty sequences`` () = task {
 [<Fact>]
 let ``TaskSeq-collectSeqAsync with empty sequences`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.collectSeqAsync (fun _ -> task { return Array.empty<int> })
         |> TaskSeq.toSeqCachedAsync
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
@@ -41,7 +41,7 @@ let ``TaskSeq-exactlyOne throws for a sequence of length = two`` () = task {
 [<Fact>]
 let ``TaskSeq-exactlyOne throws for a sequence of length = two - variant`` () = task {
     fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 2
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 2
         |> TaskSeq.exactlyOne
         |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
@@ -51,7 +51,7 @@ let ``TaskSeq-exactlyOne throws for a sequence of length = two - variant`` () = 
 [<Fact>]
 let ``TaskSeq-exactlyOne throws with a larger sequence`` () = task {
     fun () ->
-        createDummyTaskSeqWith 50L<µs> 300L<µs> 200
+        Gen.sideEffectTaskSeqMicro 50L<µs> 300L<µs> 200
         |> TaskSeq.exactlyOne
         |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
@@ -60,7 +60,7 @@ let ``TaskSeq-exactlyOne throws with a larger sequence`` () = task {
 [<Fact>]
 let ``TaskSeq-tryExactlyOne returns None with a larger sequence`` () = task {
     let! nothing =
-        createDummyTaskSeqWith 50L<µs> 300L<µs> 20
+        Gen.sideEffectTaskSeqMicro 50L<µs> 300L<µs> 20
         |> TaskSeq.tryExactlyOne
 
     nothing |> should be None'
@@ -82,7 +82,7 @@ let ``TaskSeq-tryExactlyOne gets the only item in a singleton sequence`` () = ta
 [<Fact>]
 let ``TaskSeq-exactlyOne gets the only item in a singleton sequence - variant`` () = task {
     let! exactlyOne =
-        createLongerDummyTaskSeq 50<ms> 300<ms> 1
+        Gen.sideEffectTaskSeqMs 50<ms> 300<ms> 1
         |> TaskSeq.exactlyOne
 
     exactlyOne |> should equal 1
@@ -91,7 +91,7 @@ let ``TaskSeq-exactlyOne gets the only item in a singleton sequence - variant`` 
 [<Fact>]
 let ``TaskSeq-tryExactlyOne gets the only item in a singleton sequence - variant`` () = task {
     let! exactlyOne =
-        createLongerDummyTaskSeq 50<ms> 300<ms> 1
+        Gen.sideEffectTaskSeqMs 50<ms> 300<ms> 1
         |> TaskSeq.tryExactlyOne
 
     exactlyOne |> should be Some'

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
@@ -30,7 +30,7 @@ let ``TaskSeq-filterAsync on an empty sequence`` () = task {
 [<Fact>]
 let ``TaskSeq-filter filters correctly`` () = task {
     let! alphabet =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.filter ((<=) 26) // lambda of '>' etc inverts order of args, so this means 'greater than'
         |> TaskSeq.map char
         |> TaskSeq.map ((+) '@')
@@ -43,7 +43,7 @@ let ``TaskSeq-filter filters correctly`` () = task {
 [<Fact>]
 let ``TaskSeq-filterAsync filters correctly`` () = task {
     let! alphabet =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.filterAsync (fun x -> task { return x <= 26 })
         |> TaskSeq.map char
         |> TaskSeq.map ((+) '@')

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Find.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Find.Tests.fs
@@ -37,7 +37,7 @@ let ``TaskSeq-findAsync on an empty sequence raises KeyNotFoundException`` () = 
 [<Fact>]
 let ``TaskSeq-find sad path raises KeyNotFoundException`` () = task {
     fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.find ((=) 0) // dummy tasks sequence starts at 1
         |> Task.ignore
 
@@ -47,7 +47,7 @@ let ``TaskSeq-find sad path raises KeyNotFoundException`` () = task {
 [<Fact>]
 let ``TaskSeq-findAsync sad path raises KeyNotFoundException`` () = task {
     fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.findAsync (fun x -> task { return x = 0 }) // dummy tasks sequence starts at 1
         |> Task.ignore
 
@@ -57,7 +57,7 @@ let ``TaskSeq-findAsync sad path raises KeyNotFoundException`` () = task {
 [<Fact>]
 let ``TaskSeq-find sad path raises KeyNotFoundException variant`` () = task {
     fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.find ((=) 51) // dummy tasks sequence ends at 50
         |> Task.ignore
 
@@ -67,7 +67,7 @@ let ``TaskSeq-find sad path raises KeyNotFoundException variant`` () = task {
 [<Fact>]
 let ``TaskSeq-findAsync sad path raises KeyNotFoundException variant`` () = task {
     fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.findAsync (fun x -> task { return x = 51 }) // dummy tasks sequence ends at 50
         |> Task.ignore
 
@@ -78,7 +78,7 @@ let ``TaskSeq-findAsync sad path raises KeyNotFoundException variant`` () = task
 [<Fact>]
 let ``TaskSeq-find happy path middle of seq`` () = task {
     let! twentyFive =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.find (fun x -> x < 26 && x > 24)
 
     twentyFive |> should equal 25
@@ -87,7 +87,7 @@ let ``TaskSeq-find happy path middle of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-findAsync happy path middle of seq`` () = task {
     let! twentyFive =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.findAsync (fun x -> task { return x < 26 && x > 24 })
 
     twentyFive |> should equal 25
@@ -96,7 +96,7 @@ let ``TaskSeq-findAsync happy path middle of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-find happy path first item of seq`` () = task {
     let! first =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.find ((=) 1) // dummy tasks seq starts at 1
 
     first |> should equal 1
@@ -105,7 +105,7 @@ let ``TaskSeq-find happy path first item of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-findAsync happy path first item of seq`` () = task {
     let! first =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.findAsync (fun x -> task { return x = 1 }) // dummy tasks seq starts at 1
 
     first |> should equal 1
@@ -114,7 +114,7 @@ let ``TaskSeq-findAsync happy path first item of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-find happy path last item of seq`` () = task {
     let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.find ((=) 50) // dummy tasks seq ends at 50
 
     last |> should equal 50
@@ -123,7 +123,7 @@ let ``TaskSeq-find happy path last item of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-findAsync happy path last item of seq`` () = task {
     let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.findAsync (fun x -> task { return x = 50 }) // dummy tasks seq ends at 50
 
     last |> should equal 50
@@ -152,7 +152,7 @@ let ``TaskSeq-tryFindAsync on an empty sequence returns None`` () = task {
 [<Fact>]
 let ``TaskSeq-tryFind sad path returns None`` () = task {
     let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryFind ((=) 0) // dummy tasks sequence starts at 1
 
     nothing |> should be None'
@@ -161,7 +161,7 @@ let ``TaskSeq-tryFind sad path returns None`` () = task {
 [<Fact>]
 let ``TaskSeq-tryFindAsync sad path return None`` () = task {
     let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryFindAsync (fun x -> task { return x = 0 }) // dummy tasks sequence starts at 1
 
     nothing |> should be None'
@@ -170,7 +170,7 @@ let ``TaskSeq-tryFindAsync sad path return None`` () = task {
 [<Fact>]
 let ``TaskSeq-tryFind sad path returns None variant`` () = task {
     let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryFind ((<=) 51) // dummy tasks sequence ends at 50 (inverted sign in lambda!)
 
     nothing |> should be None'
@@ -179,7 +179,7 @@ let ``TaskSeq-tryFind sad path returns None variant`` () = task {
 [<Fact>]
 let ``TaskSeq-tryFindAsync sad path return None - variant`` () = task {
     let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryFindAsync (fun x -> task { return x >= 51 }) // dummy tasks sequence ends at 50
 
     nothing |> should be None'
@@ -189,7 +189,7 @@ let ``TaskSeq-tryFindAsync sad path return None - variant`` () = task {
 [<Fact>]
 let ``TaskSeq-tryFind happy path middle of seq`` () = task {
     let! twentyFive =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryFind (fun x -> x < 26 && x > 24)
 
     twentyFive |> should be Some'
@@ -199,7 +199,7 @@ let ``TaskSeq-tryFind happy path middle of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-tryFindAsync happy path middle of seq`` () = task {
     let! twentyFive =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryFindAsync (fun x -> task { return x < 26 && x > 24 })
 
     twentyFive |> should be Some'
@@ -209,7 +209,7 @@ let ``TaskSeq-tryFindAsync happy path middle of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-tryFind happy path first item of seq`` () = task {
     let! first =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryFind ((=) 1) // dummy tasks seq starts at 1
 
     first |> should be Some'
@@ -219,7 +219,7 @@ let ``TaskSeq-tryFind happy path first item of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-tryFindAsync happy path first item of seq`` () = task {
     let! first =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryFindAsync (fun x -> task { return x = 1 }) // dummy tasks seq starts at 1
 
     first |> should be Some'
@@ -229,7 +229,7 @@ let ``TaskSeq-tryFindAsync happy path first item of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-tryFind happy path last item of seq`` () = task {
     let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryFind ((=) 50) // dummy tasks seq ends at 50
 
     last |> should be Some'
@@ -239,7 +239,7 @@ let ``TaskSeq-tryFind happy path last item of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-tryFindAsync happy path last item of seq`` () = task {
     let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryFindAsync (fun x -> task { return x = 50 }) // dummy tasks seq ends at 50
 
     last |> should be Some'

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
@@ -11,7 +11,7 @@ open FSharpy
 [<Fact>]
 let ``TaskSeq-fold folds with every item`` () = task {
     let! alphabet =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 26
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 26
         |> TaskSeq.fold (fun (state: StringBuilder) item -> state.Append(char item + '@')) (StringBuilder())
 
     alphabet.ToString()
@@ -21,7 +21,7 @@ let ``TaskSeq-fold folds with every item`` () = task {
 [<Fact>]
 let ``TaskSeq-foldAsync folds with every item`` () = task {
     let! alphabet =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 26
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 26
         |> TaskSeq.foldAsync
             (fun (state: StringBuilder) item -> task { return state.Append(char item + '@') })
             (StringBuilder())

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
@@ -28,7 +28,9 @@ let ``TaskSeq-tryHead returns None on empty sequences`` () = task {
 
 [<Fact>]
 let ``TaskSeq-head gets the first item in a longer sequence`` () = task {
-    let! head = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50 |> TaskSeq.head
+    let! head =
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
+        |> TaskSeq.head
 
     head |> should equal 1
 }
@@ -42,7 +44,7 @@ let ``TaskSeq-head gets the only item in a singleton sequence`` () = task {
 [<Fact>]
 let ``TaskSeq-tryHead gets the first item in a longer sequence`` () = task {
     let! head =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryHead
 
     head |> should be Some'

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
@@ -165,7 +165,9 @@ let ``TaskSeq-tryItem can get the first item in a longer sequence`` () = task {
 
 [<Fact>]
 let ``TaskSeq-tryItem in a very long sequence (5_000 items - slow variant)`` () = task {
-    let! head = Gen.sideEffectTaskSeq_Sequential 5_001 |> TaskSeq.tryItem 5_000 // zero-based!
+    let! head =
+        Gen.sideEffectTaskSeq_Sequential 5_001
+        |> TaskSeq.tryItem 5_000 // zero-based!
 
     head |> should be Some'
     head |> should equal (Some 5_001)
@@ -173,7 +175,9 @@ let ``TaskSeq-tryItem in a very long sequence (5_000 items - slow variant)`` () 
 
 [<Fact>]
 let ``TaskSeq-tryItem in a very long sequence (50_000 items - slow variant)`` () = task {
-    let! head = Gen.sideEffectTaskSeq_Sequential 50_001 |> TaskSeq.tryItem 50_000 // zero-based!
+    let! head =
+        Gen.sideEffectTaskSeq_Sequential 50_001
+        |> TaskSeq.tryItem 50_000 // zero-based!
 
     head |> should be Some'
     head |> should equal (Some 50_001)

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
@@ -23,7 +23,7 @@ let ``TaskSeq-item throws on empty sequence - variant`` () = task {
 [<Fact>]
 let ``TaskSeq-item throws when not found`` () = task {
     fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.item 51
         |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
@@ -32,7 +32,7 @@ let ``TaskSeq-item throws when not found`` () = task {
 [<Fact>]
 let ``TaskSeq-item throws when not found - variant`` () = task {
     fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.item Int32.MaxValue
         |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
@@ -46,7 +46,7 @@ let ``TaskSeq-item throws when accessing 2nd item in singleton sequence`` () = t
 
 [<Fact>]
 let ``TaskSeq-item always throws with negative values`` () = task {
-    let make50 () = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+    let make50 () = Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
 
     fun () -> make50 () |> TaskSeq.item -1 |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
@@ -85,7 +85,7 @@ let ``TaskSeq-tryItem returns None on empty sequence - variant`` () = task {
 [<Fact>]
 let ``TaskSeq-tryItem returns None when not found`` () = task {
     let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryItem 50 // zero-based index, so a sequence of 50 items has its last item at index 49
 
     nothing |> should be None'
@@ -94,7 +94,7 @@ let ``TaskSeq-tryItem returns None when not found`` () = task {
 [<Fact>]
 let ``TaskSeq-tryItem returns None when not found - variant`` () = task {
     let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryItem Int32.MaxValue
 
     nothing |> should be None'
@@ -108,7 +108,7 @@ let ``TaskSeq-tryItem returns None when accessing 2nd item in singleton sequence
 
 [<Fact>]
 let ``TaskSeq-tryItem returns None throws with negative values`` () = task {
-    let make50 () = createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+    let make50 () = Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
 
     let! nothing = make50 () |> TaskSeq.tryItem -1
     nothing |> should be None'
@@ -132,7 +132,7 @@ let ``TaskSeq-tryItem returns None throws with negative values`` () = task {
 [<Fact>]
 let ``TaskSeq-item can get the first item in a longer sequence`` () = task {
     let! head =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.item 0
 
     head |> should equal 1
@@ -141,7 +141,7 @@ let ``TaskSeq-item can get the first item in a longer sequence`` () = task {
 [<Fact>]
 let ``TaskSeq-item can get the last item in a longer sequence`` () = task {
     let! head =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.item 49
 
     head |> should equal 50
@@ -156,7 +156,7 @@ let ``TaskSeq-item can get the first item in a singleton sequence`` () = task {
 [<Fact>]
 let ``TaskSeq-tryItem can get the first item in a longer sequence`` () = task {
     let! head =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryItem 0 // zero-based!
 
     head |> should be Some'
@@ -165,7 +165,7 @@ let ``TaskSeq-tryItem can get the first item in a longer sequence`` () = task {
 
 [<Fact>]
 let ``TaskSeq-tryItem in a very long sequence (5_000 items - slow variant)`` () = task {
-    let! head = createDummyDirectTaskSeq 5_001 |> TaskSeq.tryItem 5_000 // zero-based!
+    let! head = Gen.sideEffectTaskSeq_Sequential 5_001 |> TaskSeq.tryItem 5_000 // zero-based!
 
     head |> should be Some'
     head |> should equal (Some 5_001)
@@ -173,7 +173,7 @@ let ``TaskSeq-tryItem in a very long sequence (5_000 items - slow variant)`` () 
 
 [<Fact>]
 let ``TaskSeq-tryItem in a very long sequence (50_000 items - slow variant)`` () = task {
-    let! head = createDummyDirectTaskSeq 50_001 |> TaskSeq.tryItem 50_000 // zero-based!
+    let! head = Gen.sideEffectTaskSeq_Sequential 50_001 |> TaskSeq.tryItem 50_000 // zero-based!
 
     head |> should be Some'
     head |> should equal (Some 50_001)

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -5,70 +5,125 @@ open FsUnit.Xunit
 
 open FSharpy
 
-[<Fact>]
-let ``TaskSeq-iteri does nothing on empty sequences`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let mutable sum = -1
-    do! TaskSeq.empty |> TaskSeq.iteri (fun i _ -> sum <- sum + i)
-    sum |> should equal -1
-}
+module EmptySeq =
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-iteri does nothing on empty sequences`` variant = task {
+        let tq = Gen.getEmptyVariant variant
+        let mutable sum = -1
+        do! tq |> TaskSeq.iteri (fun i _ -> sum <- sum + i)
+        sum |> should equal -1
+    }
 
-[<Fact>]
-let ``TaskSeq-iter does nothing on empty sequences`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let mutable sum = -1
-    do! TaskSeq.empty |> TaskSeq.iter (fun i -> sum <- sum + i)
-    sum |> should equal -1
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-iter does nothing on empty sequences`` variant = task {
+        let tq = Gen.getEmptyVariant variant
+        let mutable sum = -1
+        do! tq |> TaskSeq.iter (fun i -> sum <- sum + i)
+        sum |> should equal -1
+    }
 
-[<Fact>]
-let ``TaskSeq-iteri should go over all items`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let mutable sum = 0
-    do! tq |> TaskSeq.iteri (fun i _ -> sum <- sum + i)
-    sum |> should equal 45 // index starts at 0
-}
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-iteri should go over all items`` variant = task {
+        let tq = Gen.getSeqImmutable variant
+        let mutable sum = 0
+        do! tq |> TaskSeq.iteri (fun i _ -> sum <- sum + i)
+        sum |> should equal 45 // index starts at 0
+    }
 
-[<Fact>]
-let ``TaskSeq-iter should go over all items`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let mutable sum = 0
-    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
-    sum |> should equal 55 // task-dummies started at 1
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-iter should go over all items`` variant = task {
+        let tq = Gen.getSeqImmutable variant
+        let mutable sum = 0
+        do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+        sum |> should equal 55 // task-dummies started at 1
+    }
 
 
-[<Fact>]
-let ``TaskSeq-iter multiple iterations over same sequence`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let mutable sum = 0
-    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
-    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
-    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
-    do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
-    sum |> should equal 820 // task-dummies started at 1
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-iter multiple iterations over same sequence`` variant = task {
+        let tq = Gen.getSeqImmutable variant
+        let mutable sum = 0
+        do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+        do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+        do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+        do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+        sum |> should equal 220 // immutable tasks, so 'item' does not change, just 4 x 55
+    }
 
-[<Fact>]
-let ``TaskSeq-iteriAsync should go over all items`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let mutable sum = 0
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-iteriAsync should go over all items`` variant = task {
+        let tq = Gen.getSeqImmutable variant
+        let mutable sum = 0
 
-    do!
-        tq
-        |> TaskSeq.iteriAsync (fun i _ -> task { sum <- sum + i })
+        do!
+            tq
+            |> TaskSeq.iteriAsync (fun i _ -> task { sum <- sum + i })
 
-    sum |> should equal 45 // index starts at 0
-}
+        sum |> should equal 45 // index starts at 0
+    }
 
-[<Fact>]
-let ``TaskSeq-iterAsync should go over all items`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let mutable sum = 0
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-iterAsync should go over all items`` variant = task {
+        let tq = Gen.getSeqImmutable variant
+        let mutable sum = 0
 
-    do!
-        tq
-        |> TaskSeq.iterAsync (fun item -> task { sum <- sum + item })
+        do!
+            tq
+            |> TaskSeq.iterAsync (fun item -> task { sum <- sum + item })
 
-    sum |> should equal 55 // task-dummies started at 1
-}
+        sum |> should equal 55 // task-dummies started at 1
+    }
+
+module SideEffects =
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-iteri should go over all items`` variant = task {
+        let tq = Gen.getSeqWithSideEffect variant
+        let mutable sum = 0
+        do! tq |> TaskSeq.iteri (fun i _ -> sum <- sum + i)
+        sum |> should equal 45 // index starts at 0
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-iter should go over all items`` variant = task {
+        let tq = Gen.getSeqWithSideEffect variant
+        let mutable sum = 0
+        do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
+        sum |> should equal 55 // task-dummies started at 1
+    }
+
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-iter multiple iterations over same sequence`` variant = task {
+        let tq = Gen.getSeqWithSideEffect variant
+        let mutable sum = 0
+        do! tq |> TaskSeq.iter (fun item -> printfn "A:%i" item; sum <- sum + item)
+        do! tq |> TaskSeq.iter (fun item -> printfn "B:%i" item; sum <- sum + item)
+        do! tq |> TaskSeq.iter (fun item -> printfn "C:%i" item; sum <- sum + item)
+        do! tq |> TaskSeq.iter (fun item -> printfn "D:%i" item; sum <- sum + item)
+        sum |> should equal 820 // side-effected tasks, so 'item' DOES CHANGE, each next iteration starts 10 higher
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-iteriAsync should go over all items`` variant = task {
+        let tq = Gen.getSeqWithSideEffect variant
+        let mutable sum = 0
+
+        do!
+            tq
+            |> TaskSeq.iteriAsync (fun i _ -> task { sum <- sum + i })
+
+        sum |> should equal 45 // index starts at 0
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-iterAsync should go over all items`` variant = task {
+        let tq = Gen.getSeqWithSideEffect variant
+        let mutable sum = 0
+
+        do!
+            tq
+            |> TaskSeq.iterAsync (fun item -> task { sum <- sum + item })
+
+        sum |> should equal 55 // task-dummies started at 1
+    }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -7,7 +7,7 @@ open FSharpy
 
 [<Fact>]
 let ``TaskSeq-iteri does nothing on empty sequences`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let mutable sum = -1
     do! TaskSeq.empty |> TaskSeq.iteri (fun i _ -> sum <- sum + i)
     sum |> should equal -1
@@ -15,7 +15,7 @@ let ``TaskSeq-iteri does nothing on empty sequences`` () = task {
 
 [<Fact>]
 let ``TaskSeq-iter does nothing on empty sequences`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let mutable sum = -1
     do! TaskSeq.empty |> TaskSeq.iter (fun i -> sum <- sum + i)
     sum |> should equal -1
@@ -23,7 +23,7 @@ let ``TaskSeq-iter does nothing on empty sequences`` () = task {
 
 [<Fact>]
 let ``TaskSeq-iteri should go over all items`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let mutable sum = 0
     do! tq |> TaskSeq.iteri (fun i _ -> sum <- sum + i)
     sum |> should equal 45 // index starts at 0
@@ -31,7 +31,7 @@ let ``TaskSeq-iteri should go over all items`` () = task {
 
 [<Fact>]
 let ``TaskSeq-iter should go over all items`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let mutable sum = 0
     do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
     sum |> should equal 55 // task-dummies started at 1
@@ -40,7 +40,7 @@ let ``TaskSeq-iter should go over all items`` () = task {
 
 [<Fact>]
 let ``TaskSeq-iter multiple iterations over same sequence`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let mutable sum = 0
     do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
     do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
@@ -51,7 +51,7 @@ let ``TaskSeq-iter multiple iterations over same sequence`` () = task {
 
 [<Fact>]
 let ``TaskSeq-iteriAsync should go over all items`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let mutable sum = 0
 
     do!
@@ -63,7 +63,7 @@ let ``TaskSeq-iteriAsync should go over all items`` () = task {
 
 [<Fact>]
 let ``TaskSeq-iterAsync should go over all items`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let mutable sum = 0
 
     do!

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
@@ -7,42 +7,133 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+module EmptySeq =
 
-[<Theory; ClassData(typeof<TestEmptyVariants>)>]
-let ``TaskSeq-last throws on empty sequences`` variant = task {
-    fun () -> Gen.getEmptyVariant variant |> TaskSeq.last |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-last throws on empty sequences`` variant = task {
+        fun () -> Gen.getEmptyVariant variant |> TaskSeq.last |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
 
-[<Theory; ClassData(typeof<TestEmptyVariants>)>]
-let ``TaskSeq-tryLast returns None on empty sequences`` variant = task {
-    let! nothing = Gen.getEmptyVariant variant |> TaskSeq.tryLast
-    nothing |> should be None'
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-tryLast returns None on empty sequences`` variant = task {
+        let! nothing = Gen.getEmptyVariant variant |> TaskSeq.tryLast
+        nothing |> should be None'
+    }
 
-[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-let ``TaskSeq-last gets the last item in a longer sequence`` variant = task {
-    let! last = Gen.getSeqImmutable variant |> TaskSeq.last
-    last |> should equal 10
-}
+    [<Fact>]
+    let ``TaskSeq-last throws on empty sequences, but side effect is executed`` () = task {
+        let mutable x = 0
 
-[<Fact>]
-let ``TaskSeq-last gets the only item in a singleton sequence`` () = task {
-    let! last = taskSeq { yield 42 } |> TaskSeq.last
-    last |> should equal 42
-}
+        fun () -> taskSeq { do x <- x + 1 } |> TaskSeq.last |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
 
-[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-let ``TaskSeq-tryLast gets the last item in a longer sequence`` variant = task {
-    let! last = Gen.getSeqImmutable variant |> TaskSeq.tryLast
+        // side effect must have run!
+        x |> should equal 1
+    }
 
-    last |> should be Some'
-    last |> should equal (Some 10)
-}
 
-[<Fact>]
-let ``TaskSeq-tryLast gets the only item in a singleton sequence`` () = task {
-    let! last = taskSeq { yield 10 } |> TaskSeq.tryLast
-    last |> should be Some'
-    last |> should equal (Some 10)
-}
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-last gets the last item in a longer sequence`` variant = task {
+        let ts = Gen.getSeqImmutable variant
+
+        let! last = TaskSeq.last ts
+        last |> should equal 10
+
+        let! last = TaskSeq.last ts //immutable, so re-iteration does not change outcome
+        last |> should equal 10
+    }
+
+    [<Fact>]
+    let ``TaskSeq-last gets the only item in a singleton sequence`` () = task {
+        let ts = taskSeq { yield 42 }
+
+        let! last = TaskSeq.last ts
+        last |> should equal 42
+
+        let! last = TaskSeq.last ts // doing it twice is fine
+        last |> should equal 42
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryLast gets the last item in a longer sequence`` variant = task {
+        let ts = Gen.getSeqImmutable variant
+
+        let! last = TaskSeq.tryLast ts
+        last |> should equal (Some 10)
+
+        let! last = TaskSeq.tryLast ts //immutable, so re-iteration does not change outcome
+        last |> should equal (Some 10)
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryLast gets the only item in a singleton sequence`` () = task {
+        let ts = taskSeq { yield 42 }
+
+        let! last = TaskSeq.tryLast ts
+        last |> should equal (Some 42)
+
+        let! last = TaskSeq.tryLast ts // doing it twice is fine
+        last |> should equal (Some 42)
+    }
+
+
+module SideEffects =
+    [<Fact>]
+    let ``TaskSeq-last gets the only item in a singleton sequence, with change`` () = task {
+        let mutable x = 42
+
+        let one = taskSeq {
+            yield x
+            x <- x + 1
+        }
+
+        let! fortytwo = one |> TaskSeq.last
+        let! fortythree = one |> TaskSeq.last // side effect, re-iterating!
+
+        fortytwo |> should equal 42
+        fortythree |> should equal 43
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryLast gets the only item in a singleton sequence, with change`` () = task {
+        let mutable x = 42
+
+        let one = taskSeq {
+            yield x
+            x <- x + 1
+        }
+
+        let! fortytwo = one |> TaskSeq.tryLast
+        fortytwo |> should equal (Some 42)
+
+        // side effect, reiterating causes it to execute again!
+        let! fortythree = one |> TaskSeq.tryLast
+        fortythree |> should equal (Some 43)
+
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-last gets the last item in a longer sequence, with change`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+
+        let! ten = TaskSeq.last ts
+        ten |> should equal 10
+
+        // side effect, reiterating causes it to execute again!
+        let! twenty = TaskSeq.last ts
+        twenty |> should equal 20
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-tryLast gets the last item in a longer sequence, with change`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+
+        let! ten = TaskSeq.tryLast ts
+        ten |> should equal (Some 10)
+
+        // side effect, reiterating causes it to execute again!
+        let! twenty = TaskSeq.tryLast ts
+        twenty |> should equal (Some 20)
+    }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
@@ -10,19 +10,19 @@ open FSharpy
 
 [<Theory; ClassData(typeof<TestEmptyVariants>)>]
 let ``TaskSeq-last throws on empty sequences`` variant = task {
-    fun () -> getEmptyVariant variant |> TaskSeq.last |> Task.ignore
+    fun () -> Gen.getEmptyVariant variant |> TaskSeq.last |> Task.ignore
     |> should throwAsyncExact typeof<ArgumentException>
 }
 
 [<Theory; ClassData(typeof<TestEmptyVariants>)>]
 let ``TaskSeq-tryLast returns None on empty sequences`` variant = task {
-    let! nothing = getEmptyVariant variant |> TaskSeq.tryLast
+    let! nothing = Gen.getEmptyVariant variant |> TaskSeq.tryLast
     nothing |> should be None'
 }
 
-[<Theory; ClassData(typeof<TestSmallVariants>)>]
+[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
 let ``TaskSeq-last gets the last item in a longer sequence`` variant = task {
-    let! last = getSmallVariant variant |> TaskSeq.last
+    let! last = Gen.getSeqImmutable variant |> TaskSeq.last
     last |> should equal 10
 }
 
@@ -32,9 +32,9 @@ let ``TaskSeq-last gets the only item in a singleton sequence`` () = task {
     last |> should equal 42
 }
 
-[<Theory; ClassData(typeof<TestSmallVariants>)>]
+[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
 let ``TaskSeq-tryLast gets the last item in a longer sequence`` variant = task {
-    let! last = getSmallVariant variant |> TaskSeq.tryLast
+    let! last = Gen.getSeqImmutable variant |> TaskSeq.tryLast
 
     last |> should be Some'
     last |> should equal (Some 10)

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
@@ -7,76 +7,128 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+module EmptySeq =
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-length returns zero on empty sequences`` variant = task {
+        let! len = Gen.getEmptyVariant variant |> TaskSeq.length
+        len |> should equal 0
+    }
 
-[<Theory; ClassData(typeof<TestEmptyVariants>)>]
-let ``TaskSeq-length returns zero on empty sequences`` variant = task {
-    let! len = Gen.getEmptyVariant variant |> TaskSeq.length
-    len |> should equal 0
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-lengthBy returns zero on empty sequences`` variant = task {
+        let! len =
+            Gen.getEmptyVariant variant
+            |> TaskSeq.lengthBy (fun _ -> true)
 
-[<Theory; ClassData(typeof<TestEmptyVariants>)>]
-let ``TaskSeq-lengthBy returns zero on empty sequences`` variant = task {
-    let! len =
-        Gen.getEmptyVariant variant
-        |> TaskSeq.lengthBy (fun _ -> true)
+        len |> should equal 0
+    }
 
-    len |> should equal 0
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-lengthByAsync returns zero on empty sequences`` variant = task {
+        let! len =
+            Gen.getEmptyVariant variant
+            |> TaskSeq.lengthByAsync (Task.apply (fun _ -> true))
 
-[<Theory; ClassData(typeof<TestEmptyVariants>)>]
-let ``TaskSeq-lengthByAsync returns zero on empty sequences`` variant = task {
-    let! len =
-        Gen.getEmptyVariant variant
-        |> TaskSeq.lengthByAsync (Task.apply (fun _ -> true))
+        len |> should equal 0
+    }
 
-    len |> should equal 0
-}
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-length returns proper length`` variant = task {
+        let! len = Gen.getSeqImmutable variant |> TaskSeq.length
+        len |> should equal 10
+    }
 
-[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-let ``TaskSeq-length returns proper length`` variant = task {
-    let! len = Gen.getSeqImmutable variant |> TaskSeq.length
-    len |> should equal 10
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-lengthBy returns proper length`` variant = task {
+        let! len =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.lengthBy (fun _ -> true)
 
-[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-let ``TaskSeq-lengthBy returns proper length`` variant = task {
-    let! len =
-        Gen.getSeqImmutable variant
-        |> TaskSeq.lengthBy (fun _ -> true)
+        len |> should equal 10
+    }
 
-    len |> should equal 10
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-lengthByAsync returns proper length`` variant = task {
+        let! len =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.lengthByAsync (Task.apply (fun _ -> true))
 
-[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-let ``TaskSeq-lengthByAsync returns proper length`` variant = task {
-    let! len =
-        Gen.getSeqImmutable variant
-        |> TaskSeq.lengthByAsync (Task.apply (fun _ -> true))
+        len |> should equal 10
+    }
 
-    len |> should equal 10
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-lengthBy returns proper length when filtering`` variant = task {
+        let run f = Gen.getSeqImmutable variant |> TaskSeq.lengthBy f
+        let! len = run (fun x -> x % 3 = 0)
+        len |> should equal 3 // [3; 6; 9]
+        let! len = run (fun x -> x % 3 = 1)
+        len |> should equal 4 // [1; 4; 7; 10]
+        let! len = run (fun x -> x % 3 = 2)
+        len |> should equal 3 // [2; 5; 8]
+    }
 
-[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-let ``TaskSeq-lengthBy returns proper length when filtering`` variant = task {
-    let run f = Gen.getSeqImmutable variant |> TaskSeq.lengthBy f
-    let! len = run (fun x -> x % 3 = 0)
-    len |> should equal 3 // [3; 6; 9]
-    let! len = run (fun x -> x % 3 = 1)
-    len |> should equal 4 // [1; 4; 7; 10]
-    let! len = run (fun x -> x % 3 = 2)
-    len |> should equal 3 // [2; 5; 8]
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-lengthByAsync returns proper length when filtering`` variant = task {
+        let run f =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.lengthByAsync (Task.apply f)
 
-[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-let ``TaskSeq-lengthByAsync returns proper length when filtering`` variant = task {
-    let run f =
-        Gen.getSeqImmutable variant
-        |> TaskSeq.lengthByAsync (Task.apply f)
+        let! len = run (fun x -> x % 3 = 0)
+        len |> should equal 3 // [3; 6; 9]
+        let! len = run (fun x -> x % 3 = 1)
+        len |> should equal 4 // [1; 4; 7; 10]
+        let! len = run (fun x -> x % 3 = 2)
+        len |> should equal 3 // [2; 5; 8]
+    }
 
-    let! len = run (fun x -> x % 3 = 0)
-    len |> should equal 3 // [3; 6; 9]
-    let! len = run (fun x -> x % 3 = 1)
-    len |> should equal 4 // [1; 4; 7; 10]
-    let! len = run (fun x -> x % 3 = 2)
-    len |> should equal 3 // [2; 5; 8]
-}
+module SideSeffects =
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-length returns proper length - side-effect`` variant = task {
+        let! len = Gen.getSeqImmutable variant |> TaskSeq.length
+        len |> should equal 10
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-lengthBy returns proper length - side-effect`` variant = task {
+        let! len =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.lengthBy (fun _ -> true)
+
+        len |> should equal 10
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-lengthByAsync returns proper length - side-effect`` variant = task {
+        let! len =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.lengthByAsync (Task.apply (fun _ -> true))
+
+        len |> should equal 10
+    }
+
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-lengthBy returns proper length when filtering - side-effect`` variant = task {
+        let run f = Gen.getSeqImmutable variant |> TaskSeq.lengthBy f
+        let! len = run (fun x -> x % 3 = 0)
+        len |> should equal 3 // [3; 6; 9]
+        let! len = run (fun x -> x % 3 = 1)
+        len |> should equal 4 // [1; 4; 7; 10]
+        let! len = run (fun x -> x % 3 = 2)
+        len |> should equal 3 // [2; 5; 8]
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-lengthByAsync returns proper length when filtering - side-effect`` variant = task {
+        let run f =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.lengthByAsync (Task.apply f)
+
+        let! len = run (fun x -> x % 3 = 0)
+        len |> should equal 3 // [3; 6; 9]
+        let! len = run (fun x -> x % 3 = 1)
+        len |> should equal 4 // [1; 4; 7; 10]
+        let! len = run (fun x -> x % 3 = 2)
+        len |> should equal 3 // [2; 5; 8]
+    }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
@@ -10,49 +10,55 @@ open FSharpy
 
 [<Theory; ClassData(typeof<TestEmptyVariants>)>]
 let ``TaskSeq-length returns zero on empty sequences`` variant = task {
-    let! len = getEmptyVariant variant |> TaskSeq.length
+    let! len = Gen.getEmptyVariant variant |> TaskSeq.length
     len |> should equal 0
 }
 
 [<Theory; ClassData(typeof<TestEmptyVariants>)>]
 let ``TaskSeq-lengthBy returns zero on empty sequences`` variant = task {
-    let! len = getEmptyVariant variant |> TaskSeq.lengthBy (fun _ -> true)
+    let! len =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.lengthBy (fun _ -> true)
+
     len |> should equal 0
 }
 
 [<Theory; ClassData(typeof<TestEmptyVariants>)>]
 let ``TaskSeq-lengthByAsync returns zero on empty sequences`` variant = task {
     let! len =
-        getEmptyVariant variant
+        Gen.getEmptyVariant variant
         |> TaskSeq.lengthByAsync (Task.apply (fun _ -> true))
 
     len |> should equal 0
 }
 
-[<Theory; ClassData(typeof<TestSmallVariants>)>]
+[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
 let ``TaskSeq-length returns proper length`` variant = task {
-    let! len = getSmallVariant variant |> TaskSeq.length
+    let! len = Gen.getSeqImmutable variant |> TaskSeq.length
     len |> should equal 10
 }
 
-[<Theory; ClassData(typeof<TestSmallVariants>)>]
+[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
 let ``TaskSeq-lengthBy returns proper length`` variant = task {
-    let! len = getSmallVariant variant |> TaskSeq.lengthBy (fun _ -> true)
+    let! len =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.lengthBy (fun _ -> true)
+
     len |> should equal 10
 }
 
-[<Theory; ClassData(typeof<TestSmallVariants>)>]
+[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
 let ``TaskSeq-lengthByAsync returns proper length`` variant = task {
     let! len =
-        getSmallVariant variant
+        Gen.getSeqImmutable variant
         |> TaskSeq.lengthByAsync (Task.apply (fun _ -> true))
 
     len |> should equal 10
 }
 
-[<Theory; ClassData(typeof<TestSmallVariants>)>]
+[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
 let ``TaskSeq-lengthBy returns proper length when filtering`` variant = task {
-    let run f = getSmallVariant variant |> TaskSeq.lengthBy f
+    let run f = Gen.getSeqImmutable variant |> TaskSeq.lengthBy f
     let! len = run (fun x -> x % 3 = 0)
     len |> should equal 3 // [3; 6; 9]
     let! len = run (fun x -> x % 3 = 1)
@@ -61,10 +67,10 @@ let ``TaskSeq-lengthBy returns proper length when filtering`` variant = task {
     len |> should equal 3 // [2; 5; 8]
 }
 
-[<Theory; ClassData(typeof<TestSmallVariants>)>]
+[<Theory; ClassData(typeof<TestImmTaskSeq>)>]
 let ``TaskSeq-lengthByAsync returns proper length when filtering`` variant = task {
     let run f =
-        getSmallVariant variant
+        Gen.getSeqImmutable variant
         |> TaskSeq.lengthByAsync (Task.apply f)
 
     let! len = run (fun x -> x % 3 = 0)

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
@@ -77,13 +77,13 @@ module Immutable =
 
 module SideSeffects =
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
-    let ``TaskSeq-length returns proper length - side-effect`` variant = task {
+    let ``TaskSeq-length returns proper length`` variant = task {
         let! len = Gen.getSeqWithSideEffect variant |> TaskSeq.length
         len |> should equal 10
     }
 
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
-    let ``TaskSeq-lengthBy returns proper length - side-effect`` variant = task {
+    let ``TaskSeq-lengthBy returns proper length`` variant = task {
         let! len =
             Gen.getSeqWithSideEffect variant
             |> TaskSeq.lengthBy (fun _ -> true)
@@ -92,7 +92,7 @@ module SideSeffects =
     }
 
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
-    let ``TaskSeq-lengthByAsync returns proper length - side-effect`` variant = task {
+    let ``TaskSeq-lengthByAsync returns proper length`` variant = task {
         let! len =
             Gen.getSeqWithSideEffect variant
             |> TaskSeq.lengthByAsync (Task.apply (fun _ -> true))
@@ -102,7 +102,7 @@ module SideSeffects =
 
 
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
-    let ``TaskSeq-lengthBy returns proper length when filtering - side-effect`` variant = task {
+    let ``TaskSeq-lengthBy returns proper length when filtering`` variant = task {
         let ts = Gen.getSeqWithSideEffect variant
         let run f = ts |> TaskSeq.lengthBy f
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
@@ -35,17 +35,22 @@ module EmptySeq =
 module Immutable =
     [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
     let ``TaskSeq-length returns proper length`` variant = task {
-        let! len = Gen.getSeqImmutable variant |> TaskSeq.length
-        len |> should equal 10
+        let ts = Gen.getSeqImmutable variant
+        do! TaskSeq.length ts |> Task.map (should equal 10)
+        do! TaskSeq.length ts |> Task.map (should equal 10) // twice is fine
     }
 
     [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
     let ``TaskSeq-lengthBy returns proper length`` variant = task {
-        let! len =
-            Gen.getSeqImmutable variant
-            |> TaskSeq.lengthBy (fun _ -> true)
+        let ts = Gen.getSeqImmutable variant
 
-        len |> should equal 10
+        do!
+            TaskSeq.lengthBy (fun _ -> true) ts
+            |> Task.map (should equal 10)
+
+        do!
+            TaskSeq.lengthBy (fun _ -> true) ts
+            |> Task.map (should equal 10) // twice is fine
     }
 
     [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
@@ -85,14 +90,14 @@ module Immutable =
 module SideSeffects =
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-length returns proper length - side-effect`` variant = task {
-        let! len = Gen.getSeqImmutable variant |> TaskSeq.length
+        let! len = Gen.getSeqWithSideEffect variant |> TaskSeq.length
         len |> should equal 10
     }
 
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-lengthBy returns proper length - side-effect`` variant = task {
         let! len =
-            Gen.getSeqImmutable variant
+            Gen.getSeqWithSideEffect variant
             |> TaskSeq.lengthBy (fun _ -> true)
 
         len |> should equal 10
@@ -101,7 +106,7 @@ module SideSeffects =
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-lengthByAsync returns proper length - side-effect`` variant = task {
         let! len =
-            Gen.getSeqImmutable variant
+            Gen.getSeqWithSideEffect variant
             |> TaskSeq.lengthByAsync (Task.apply (fun _ -> true))
 
         len |> should equal 10
@@ -110,7 +115,8 @@ module SideSeffects =
 
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-lengthBy returns proper length when filtering - side-effect`` variant = task {
-        let run f = Gen.getSeqImmutable variant |> TaskSeq.lengthBy f
+        let ts = Gen.getSeqWithSideEffect variant
+        let run f = ts |> TaskSeq.lengthBy f
         let! len = run (fun x -> x % 3 = 0)
         len |> should equal 3 // [3; 6; 9]
         let! len = run (fun x -> x % 3 = 1)

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -28,7 +28,7 @@ let validateSequenceWithOffset offset sequence =
 [<Fact>]
 let ``TaskSeq-map maps in correct order`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.map (fun item -> char (item + 64))
         |> TaskSeq.toSeqCachedAsync
 
@@ -38,7 +38,7 @@ let ``TaskSeq-map maps in correct order`` () = task {
 [<Fact>]
 let ``TaskSeq-mapi maps in correct order`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.mapi (fun i _ -> char (i + 65))
         |> TaskSeq.toSeqCachedAsync
 
@@ -50,7 +50,7 @@ let ``TaskSeq-map can access mutables which are mutated in correct order`` () = 
     let mutable sum = 0
 
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.map (fun item ->
             sum <- sum + 1
             char (sum + 64))
@@ -65,7 +65,7 @@ let ``TaskSeq-mapi can access mutables which are mutated in correct order`` () =
     let mutable sum = 0
 
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.mapi (fun i _ ->
             sum <- i + 1
             char (sum + 64))
@@ -78,7 +78,7 @@ let ``TaskSeq-mapi can access mutables which are mutated in correct order`` () =
 [<Fact>]
 let ``TaskSeq-mapAsync maps in correct order`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
         |> TaskSeq.toSeqCachedAsync
 
@@ -91,7 +91,7 @@ let ``TaskSeq-mapAsync can map the same sequence multiple times`` () = task {
         TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
         >> TaskSeq.toSeqCachedAsync
 
-    let ts = createDummyDirectTaskSeq 10
+    let ts = Gen.sideEffectTaskSeq_Sequential 10
 
     let! result1 = mapAndCache ts
     let! result2 = mapAndCache ts
@@ -109,7 +109,7 @@ let ``TaskSeq-mapAsync can map the same sequence multiple times`` () = task {
 [<Fact>]
 let ``TaskSeq-mapiAsync maps in correct order`` () = task {
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.mapiAsync (fun i _ -> task { return char (i + 65) })
         |> TaskSeq.toSeqCachedAsync
 
@@ -122,7 +122,7 @@ let ``TaskSeq-mapAsync can access mutables which are mutated in correct order`` 
     let mutable sum = 0
 
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.mapAsync (fun item -> task {
             sum <- sum + 1
             return char (sum + 64)
@@ -138,7 +138,7 @@ let ``TaskSeq-mapiAsync can access mutables which are mutated in correct order``
     let mutable data = '0'
 
     let! sq =
-        createDummyTaskSeq 10
+        Gen.sideEffectTaskSeq 10
         |> TaskSeq.mapiAsync (fun i _ -> task {
             data <- char (i + 65)
             return data

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Pick.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Pick.Tests.fs
@@ -45,7 +45,7 @@ let ``TaskSeq-pickAsync on an empty sequence raises KeyNotFoundException`` () = 
 [<Fact>]
 let ``TaskSeq-pick sad path raises KeyNotFoundException`` () = task {
     fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.pick (fun x -> if x = 0 then Some x else None) // dummy tasks sequence starts at 1
         |> Task.ignore
 
@@ -55,7 +55,7 @@ let ``TaskSeq-pick sad path raises KeyNotFoundException`` () = task {
 [<Fact>]
 let ``TaskSeq-pickAsync sad path raises KeyNotFoundException`` () = task {
     fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.pickAsync (fun x -> task { return if x < 0 then Some x else None }) // dummy tasks sequence starts at 1
         |> Task.ignore
 
@@ -65,7 +65,7 @@ let ``TaskSeq-pickAsync sad path raises KeyNotFoundException`` () = task {
 [<Fact>]
 let ``TaskSeq-pick sad path raises KeyNotFoundException variant`` () = task {
     fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.pick (fun x -> if x = 51 then Some x else None) // dummy tasks sequence ends at 50
         |> Task.ignore
 
@@ -75,7 +75,7 @@ let ``TaskSeq-pick sad path raises KeyNotFoundException variant`` () = task {
 [<Fact>]
 let ``TaskSeq-pickAsync sad path raises KeyNotFoundException variant`` () = task {
     fun () ->
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.pickAsync (fun x -> task { return if x = 51 then Some x else None }) // dummy tasks sequence ends at 50
         |> Task.ignore
 
@@ -86,7 +86,7 @@ let ``TaskSeq-pickAsync sad path raises KeyNotFoundException variant`` () = task
 [<Fact>]
 let ``TaskSeq-pick happy path middle of seq`` () = task {
     let! twentyFive =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.pick (fun x -> if x < 26 && x > 24 then Some "foo" else None)
 
     twentyFive |> should equal "foo"
@@ -95,7 +95,7 @@ let ``TaskSeq-pick happy path middle of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-pickAsync happy path middle of seq`` () = task {
     let! twentyFive =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.pickAsync (fun x -> task { return if x < 26 && x > 24 then Some "foo" else None })
 
     twentyFive |> should equal "foo"
@@ -104,7 +104,7 @@ let ``TaskSeq-pickAsync happy path middle of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-pick happy path first item of seq`` () = task {
     let! first =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.pick (fun x -> if x = 1 then Some $"first{x}" else None) // dummy tasks seq starts at 1
 
     first |> should equal "first1"
@@ -113,7 +113,7 @@ let ``TaskSeq-pick happy path first item of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-pickAsync happy path first item of seq`` () = task {
     let! first =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.pickAsync (fun x -> task { return if x = 1 then Some $"first{x}" else None }) // dummy tasks seq starts at 1
 
     first |> should equal "first1"
@@ -122,7 +122,7 @@ let ``TaskSeq-pickAsync happy path first item of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-pick happy path last item of seq`` () = task {
     let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.pick (fun x -> if x = 50 then Some $"last{x}" else None) // dummy tasks seq ends at 50
 
     last |> should equal "last50"
@@ -131,7 +131,7 @@ let ``TaskSeq-pick happy path last item of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-pickAsync happy path last item of seq`` () = task {
     let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.pickAsync (fun x -> task { return if x = 50 then Some $"last{x}" else None }) // dummy tasks seq ends at 50
 
     last |> should equal "last50"
@@ -163,7 +163,7 @@ let ``TaskSeq-tryPickAsync on an empty sequence returns None`` () = task {
 [<Fact>]
 let ``TaskSeq-tryPick sad path returns None`` () = task {
     let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryPick (fun x -> if x = 0 then Some x else None) // dummy tasks sequence starts at 1
 
     nothing |> should be None'
@@ -172,7 +172,7 @@ let ``TaskSeq-tryPick sad path returns None`` () = task {
 [<Fact>]
 let ``TaskSeq-tryPickAsync sad path return None`` () = task {
     let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryPickAsync (fun x -> task { return if x = 0 then Some x else None }) // dummy tasks sequence starts at 1
 
     nothing |> should be None'
@@ -181,7 +181,7 @@ let ``TaskSeq-tryPickAsync sad path return None`` () = task {
 [<Fact>]
 let ``TaskSeq-tryPick sad path returns None variant`` () = task {
     let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryPick (fun x -> if x >= 51 then Some x else None) // dummy tasks sequence ends at 50 (inverted sign in lambda!)
 
     nothing |> should be None'
@@ -190,7 +190,7 @@ let ``TaskSeq-tryPick sad path returns None variant`` () = task {
 [<Fact>]
 let ``TaskSeq-tryPickAsync sad path return None - variant`` () = task {
     let! nothing =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryPickAsync (fun x -> task { return if x >= 51 then Some x else None }) // dummy tasks sequence ends at 50
 
     nothing |> should be None'
@@ -200,7 +200,7 @@ let ``TaskSeq-tryPickAsync sad path return None - variant`` () = task {
 [<Fact>]
 let ``TaskSeq-tryPick happy path middle of seq`` () = task {
     let! twentyFive =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryPick (fun x -> if x < 26 && x > 24 then Some $"foo{x}" else None)
 
     twentyFive |> should be Some'
@@ -210,7 +210,7 @@ let ``TaskSeq-tryPick happy path middle of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-tryPickAsync happy path middle of seq`` () = task {
     let! twentyFive =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryPickAsync (fun x -> task { return if x < 26 && x > 24 then Some $"foo{x}" else None })
 
     twentyFive |> should be Some'
@@ -220,7 +220,7 @@ let ``TaskSeq-tryPickAsync happy path middle of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-tryPick happy path first item of seq`` () = task {
     let! first =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryPick (sprintf "foo%i" >> Some) // dummy tasks seq starts at 1
 
     first |> should be Some'
@@ -230,7 +230,7 @@ let ``TaskSeq-tryPick happy path first item of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-tryPickAsync happy path first item of seq`` () = task {
     let! first =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryPickAsync (fun x -> task { return (sprintf "foo%i" >> Some) x }) // dummy tasks seq starts at 1
 
     first |> should be Some'
@@ -240,7 +240,7 @@ let ``TaskSeq-tryPickAsync happy path first item of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-tryPick happy path last item of seq`` () = task {
     let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryPick (fun x -> if x = 50 then Some $"foo{x}" else None) // dummy tasks seq ends at 50
 
     last |> should be Some'
@@ -250,7 +250,7 @@ let ``TaskSeq-tryPick happy path last item of seq`` () = task {
 [<Fact>]
 let ``TaskSeq-tryPickAsync happy path last item of seq`` () = task {
     let! last =
-        createDummyTaskSeqWith 50L<µs> 1000L<µs> 50
+        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
         |> TaskSeq.tryPickAsync (fun x -> task { return if x = 50 then Some $"foo{x}" else None }) // dummy tasks seq ends at 50
 
     last |> should be Some'

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.PocTests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.PocTests.fs
@@ -20,13 +20,13 @@ module ``PoC's for seq of tasks`` =
     [<Fact>]
     let ``Good: Show joining tasks with continuation is good`` () = task {
         // acts like a fold
-        let! results = createAndJoinMultipleTasks 10 joinWithContinuation
+        let! results = Gen.createAndJoinMultipleTasks 10 Gen.joinWithContinuation
         results |> should equal 10
     }
 
     [<Fact>]
     let ``Good: Show that joining tasks with 'bind' in task CE is good`` () = task {
-        let! tasks = createAndJoinMultipleTasks 10 joinIdentityDelayed
+        let! tasks = Gen.createAndJoinMultipleTasks 10 Gen.joinIdentityDelayed
 
         let tasks = tasks |> Array.ofList
         let len = Array.length tasks
@@ -42,7 +42,7 @@ module ``PoC's for seq of tasks`` =
 
     [<Fact>]
     let ``Good: Show that joining tasks with 'taskSeq' is good`` () = task {
-        let! tasks = createAndJoinMultipleTasks 10 joinIdentityDelayed
+        let! tasks = Gen.createAndJoinMultipleTasks 10 Gen.joinIdentityDelayed
 
         let asAsyncSeq = taskSeq {
             for task in tasks do
@@ -59,7 +59,7 @@ module ``PoC's for seq of tasks`` =
 
     [<Fact>]
     let ``Bad: Show that joining tasks with 'traverseTaskResult' can be bad`` () = task {
-        let! taskList = createAndJoinMultipleTasks 10 joinIdentityHotStarted
+        let! taskList = Gen.createAndJoinMultipleTasks 10 Gen.joinIdentityHotStarted
 
         // since tasks are hot-started, by this time they are already *all* running
         let! results =
@@ -69,6 +69,7 @@ module ``PoC's for seq of tasks`` =
 
         match results with
         | Ok results ->
+            // BAD!! As you can see, results are unequal to expected output
             results |> should not'
             <| equal (List.init (List.length results) ((+) 1))
         | Error err -> failwith $"Impossible: {err}"
@@ -76,7 +77,7 @@ module ``PoC's for seq of tasks`` =
 
     [<Fact>]
     let ``Bad: Show that joining tasks as a list of tasks can be bad`` () = task {
-        let! taskList = createAndJoinMultipleTasks 10 joinIdentityHotStarted
+        let! taskList = Gen.createAndJoinMultipleTasks 10 Gen.joinIdentityHotStarted
 
         // since tasks are hot-started, by this time they are already *all* running
         let tasks = taskList |> Array.ofList
@@ -86,6 +87,7 @@ module ``PoC's for seq of tasks`` =
             let! item = tasks[i]
             results[i] <- item
 
+        // BAD!! As you can see, results are unequal to expected output
         results |> should not'
         <| equal (Array.init (Array.length results) ((+) 1))
     }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug-delayed.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug-delayed.Tests.CE.fs
@@ -41,9 +41,9 @@ let ``CE taskSeq, call Current after MoveNextAsync returns false`` () = task {
     }
 
     let enum = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheck true enum // first item
-    do! moveNextAndCheck true enum // second item
-    do! moveNextAndCheck false enum // third item: false
+    do! Assert.moveNextAndCheck true enum // first item
+    do! Assert.moveNextAndCheck true enum // second item
+    do! Assert.moveNextAndCheck false enum // third item: false
 
     // call Current *after* MoveNextAsync returns false
     enum.Current |> should be Null // we return Unchecked.defaultof
@@ -59,10 +59,10 @@ let ``CE taskSeq, MoveNext once too far`` () = task {
     }
 
     let enum = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheck true enum // first item
-    do! moveNextAndCheck true enum // second item
-    do! moveNextAndCheck false enum // third item: false
-    do! moveNextAndCheck false enum // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheck true enum // first item
+    do! Assert.moveNextAndCheck true enum // second item
+    do! Assert.moveNextAndCheck false enum // third item: false
+    do! Assert.moveNextAndCheck false enum // this used to be an error, see issue #39 and PR #42
 }
 
 [<Fact>]
@@ -78,13 +78,13 @@ let ``CE taskSeq, MoveNext too far`` () = task {
     let enum = tskSeq.GetAsyncEnumerator()
 
     // first get past the post
-    do! moveNextAndCheck true enum // first item
-    do! moveNextAndCheck true enum // second item
-    do! moveNextAndCheck false enum // third item: false
+    do! Assert.moveNextAndCheck true enum // first item
+    do! Assert.moveNextAndCheck true enum // second item
+    do! Assert.moveNextAndCheck false enum // third item: false
 
     // then call it bunch of times to ensure we don't get an InvalidOperationException, see issue #39 and PR #42
     for i in 0..100 do
-        do! moveNextAndCheck false enum
+        do! Assert.moveNextAndCheck false enum
 
     // after whatever amount of time MoveNextAsync, we can still safely call Current
     enum.Current |> should equal Guid.Empty // we return Unchecked.defaultof, which is Guid.Empty for guids
@@ -104,16 +104,16 @@ let ``CE taskSeq, call GetAsyncEnumerator twice, both should have equal behavior
     let enum2 = tskSeq.GetAsyncEnumerator()
 
     // enum1
-    do! moveNextAndCheckCurrent true 1 enum1 // first item
-    do! moveNextAndCheckCurrent true 2 enum1 // second item
-    do! moveNextAndCheckCurrent false 0 enum1 // third item: false
-    do! moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheckCurrent true 1 enum1 // first item
+    do! Assert.moveNextAndCheckCurrent true 2 enum1 // second item
+    do! Assert.moveNextAndCheckCurrent false 0 enum1 // third item: false
+    do! Assert.moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
 
     // enum2
-    do! moveNextAndCheckCurrent true 1 enum2 // first item
-    do! moveNextAndCheckCurrent true 2 enum2 // second item
-    do! moveNextAndCheckCurrent false 0 enum2 // third item: false
-    do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheckCurrent true 1 enum2 // first item
+    do! Assert.moveNextAndCheckCurrent true 2 enum2 // second item
+    do! Assert.moveNextAndCheckCurrent false 0 enum2 // third item: false
+    do! Assert.moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
 // Note: this test used to cause xUnit to crash (#42), please leave it in, no matter how silly it looks
@@ -130,17 +130,17 @@ let ``CE taskSeq, cal GetAsyncEnumerator twice -- in lockstep`` () = task {
     let enum2 = tskSeq.GetAsyncEnumerator()
 
     // enum1 & enum2 in lock step
-    do! moveNextAndCheckCurrent true 1 enum1 // first item
-    do! moveNextAndCheckCurrent true 1 enum2 // first item
+    do! Assert.moveNextAndCheckCurrent true 1 enum1 // first item
+    do! Assert.moveNextAndCheckCurrent true 1 enum2 // first item
 
-    do! moveNextAndCheckCurrent true 2 enum1 // second item
-    do! moveNextAndCheckCurrent true 2 enum2 // second item
+    do! Assert.moveNextAndCheckCurrent true 2 enum1 // second item
+    do! Assert.moveNextAndCheckCurrent true 2 enum2 // second item
 
-    do! moveNextAndCheckCurrent false 0 enum1 // third item: false
-    do! moveNextAndCheckCurrent false 0 enum2 // third item: false
+    do! Assert.moveNextAndCheckCurrent false 0 enum1 // third item: false
+    do! Assert.moveNextAndCheckCurrent false 0 enum2 // third item: false
 
-    do! moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
-    do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
 // Note: this test used to cause xUnit to crash (#42), please leave it in, no matter how silly it looks
@@ -154,17 +154,17 @@ let ``CE taskSeq, call GetAsyncEnumerator twice -- after full iteration`` () = t
 
     // enum1
     let enum1 = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheckCurrent true 1 enum1 // first item
-    do! moveNextAndCheckCurrent true 2 enum1 // second item
-    do! moveNextAndCheckCurrent false 0 enum1 // third item: false
-    do! moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheckCurrent true 1 enum1 // first item
+    do! Assert.moveNextAndCheckCurrent true 2 enum1 // second item
+    do! Assert.moveNextAndCheckCurrent false 0 enum1 // third item: false
+    do! Assert.moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
 
     // enum2
     let enum2 = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheckCurrent true 1 enum2 // first item
-    do! moveNextAndCheckCurrent true 2 enum2 // second item
-    do! moveNextAndCheckCurrent false 0 enum2 // third item: false
-    do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheckCurrent true 1 enum2 // first item
+    do! Assert.moveNextAndCheckCurrent true 2 enum2 // second item
+    do! Assert.moveNextAndCheckCurrent false 0 enum2 // third item: false
+    do! Assert.moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
 // Note: this test used to hang (#42), please leave it in, no matter how silly it looks
@@ -182,7 +182,7 @@ let ``CE taskSeq, call GetAsyncEnumerator twice -- random mixed iteration`` () =
     let enum1 = tskSeq.GetAsyncEnumerator()
 
     // move #1
-    do! moveNextAndCheckCurrent true 1 enum1 // first item
+    do! Assert.moveNextAndCheckCurrent true 1 enum1 // first item
 
     // enum2
     let enum2 = tskSeq.GetAsyncEnumerator()
@@ -190,37 +190,37 @@ let ``CE taskSeq, call GetAsyncEnumerator twice -- random mixed iteration`` () =
     enum2.Current |> should equal 0 // should be at default location
 
     // move #2
-    do! moveNextAndCheckCurrent true 1 enum2
+    do! Assert.moveNextAndCheckCurrent true 1 enum2
     enum1.Current |> should equal 1
     enum2.Current |> should equal 1
 
     // move #2
-    do! moveNextAndCheckCurrent true 2 enum2
+    do! Assert.moveNextAndCheckCurrent true 2 enum2
     enum1.Current |> should equal 1
     enum2.Current |> should equal 2
 
     // move #1
-    do! moveNextAndCheckCurrent true 2 enum1
+    do! Assert.moveNextAndCheckCurrent true 2 enum1
     enum1.Current |> should equal 2
     enum2.Current |> should equal 2
 
     // move #1
-    do! moveNextAndCheckCurrent true 3 enum1
+    do! Assert.moveNextAndCheckCurrent true 3 enum1
     enum1.Current |> should equal 3
     enum2.Current |> should equal 2
 
     // move #1
-    do! moveNextAndCheckCurrent false 0 enum1
+    do! Assert.moveNextAndCheckCurrent false 0 enum1
     enum1.Current |> should equal 0
     enum2.Current |> should equal 2
 
     // move #2
-    do! moveNextAndCheckCurrent true 3 enum2
+    do! Assert.moveNextAndCheckCurrent true 3 enum2
     enum1.Current |> should equal 0
     enum2.Current |> should equal 3
 
     // move #2
-    do! moveNextAndCheckCurrent false 0 enum2
+    do! Assert.moveNextAndCheckCurrent false 0 enum2
     enum1.Current |> should equal 0
 }
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
@@ -18,22 +18,22 @@ let ``CE empty taskSeq with MoveNextAsync -- untyped`` () = task {
     Assert.IsAssignableFrom<IAsyncEnumerable<obj>>(tskSeq)
     |> ignore
 
-    do! moveNextAndCheck false (tskSeq.GetAsyncEnumerator())
+    do! Assert.moveNextAndCheck false (tskSeq.GetAsyncEnumerator())
 }
 
 [<Theory; ClassData(typeof<TestEmptyVariants>)>]
 let ``CE empty taskSeq with MoveNextAsync -- typed`` variant = task {
-    let tskSeq = getEmptyVariant variant
+    let tskSeq = Gen.getEmptyVariant variant
 
     Assert.IsAssignableFrom<IAsyncEnumerable<int>>(tskSeq)
     |> ignore
 
-    do! moveNextAndCheck false (tskSeq.GetAsyncEnumerator())
+    do! Assert.moveNextAndCheck false (tskSeq.GetAsyncEnumerator())
 }
 
 [<Theory; ClassData(typeof<TestEmptyVariants>)>]
 let ``CE  empty taskSeq, GetAsyncEnumerator multiple times`` variant = task {
-    let tskSeq = getEmptyVariant variant
+    let tskSeq = Gen.getEmptyVariant variant
     use _e = tskSeq.GetAsyncEnumerator()
     use _e = tskSeq.GetAsyncEnumerator()
     use _e = tskSeq.GetAsyncEnumerator()
@@ -42,37 +42,37 @@ let ``CE  empty taskSeq, GetAsyncEnumerator multiple times`` variant = task {
 
 [<Theory; ClassData(typeof<TestEmptyVariants>)>]
 let ``CE  empty taskSeq, GetAsyncEnumerator multiple times and then MoveNextAsync`` variant = task {
-    let tskSeq = getEmptyVariant variant
+    let tskSeq = Gen.getEmptyVariant variant
     use enumerator = tskSeq.GetAsyncEnumerator()
     use enumerator = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheck false enumerator
+    do! Assert.moveNextAndCheck false enumerator
 }
 
 [<Theory; ClassData(typeof<TestEmptyVariants>)>]
 let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync multiple times`` variant = task {
-    let tskSeq = getEmptyVariant variant
+    let tskSeq = Gen.getEmptyVariant variant
     use enumerator1 = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheck false enumerator1
+    do! Assert.moveNextAndCheck false enumerator1
 
     // getting the enumerator again
     use enumerator2 = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheck false enumerator1 // original should still work without raising
-    do! moveNextAndCheck false enumerator2 // new hone should also work without raising
+    do! Assert.moveNextAndCheck false enumerator1 // original should still work without raising
+    do! Assert.moveNextAndCheck false enumerator2 // new hone should also work without raising
 }
 
 [<Theory; ClassData(typeof<TestEmptyVariants>)>]
 let ``CE empty taskSeq, GetAsyncEnumerator + MoveNextAsync 100x in a loop`` variant = task {
-    let tskSeq = getEmptyVariant variant
+    let tskSeq = Gen.getEmptyVariant variant
 
     // let's get the enumerator a few times
     for i in 0..100 do
         use enumerator = tskSeq.GetAsyncEnumerator()
-        do! moveNextAndCheck false enumerator // these are all empty
+        do! Assert.moveNextAndCheck false enumerator // these are all empty
 }
 
 [<Theory; ClassData(typeof<TestEmptyVariants>)>]
 let ``CE empty taskSeq, call Current before MoveNextAsync`` variant = task {
-    let tskSeq = getEmptyVariant variant
+    let tskSeq = Gen.getEmptyVariant variant
     let enumerator = tskSeq.GetAsyncEnumerator()
 
     // call Current *before* MoveNextAsync
@@ -82,9 +82,9 @@ let ``CE empty taskSeq, call Current before MoveNextAsync`` variant = task {
 
 [<Theory; ClassData(typeof<TestEmptyVariants>)>]
 let ``CE empty taskSeq, call Current after MoveNextAsync returns false`` variant = task {
-    let tskSeq = getEmptyVariant variant
+    let tskSeq = Gen.getEmptyVariant variant
     let enumerator = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheck false enumerator // false for empty seq
+    do! Assert.moveNextAndCheck false enumerator // false for empty seq
 
     // call Current *after* MoveNextAsync returns false
     enumerator.Current |> should equal 0 // we return Unchecked.defaultof, which is Zero in the case of an integer
@@ -98,11 +98,11 @@ let ``CE taskSeq, proper two-item task sequence`` () = task {
     }
 
     let enum = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheck true enum // first item
+    do! Assert.moveNextAndCheck true enum // first item
     enum.Current |> should equal "foo"
-    do! moveNextAndCheck true enum // second item
+    do! Assert.moveNextAndCheck true enum // second item
     enum.Current |> should equal "bar"
-    do! moveNextAndCheck false enum // third item: false
+    do! Assert.moveNextAndCheck false enum // third item: false
 }
 
 [<Fact>]
@@ -114,11 +114,11 @@ let ``CE taskSeq, proper two-item task sequence -- async variant`` () = task {
     }
 
     let enum = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheck true enum // first item
+    do! Assert.moveNextAndCheck true enum // first item
     enum.Current |> should equal "foo"
-    do! moveNextAndCheck true enum // second item
+    do! Assert.moveNextAndCheck true enum // second item
     enum.Current |> should equal "bar"
-    do! moveNextAndCheck false enum // third item: false
+    do! Assert.moveNextAndCheck false enum // third item: false
 }
 
 [<Fact>]
@@ -143,9 +143,9 @@ let ``CE taskSeq, call Current after MoveNextAsync returns false`` () = task {
     }
 
     let enum = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheck true enum // first item
-    do! moveNextAndCheck true enum // second item
-    do! moveNextAndCheck false enum // third item: false
+    do! Assert.moveNextAndCheck true enum // first item
+    do! Assert.moveNextAndCheck true enum // second item
+    do! Assert.moveNextAndCheck false enum // third item: false
 
     // call Current *after* MoveNextAsync returns false
     enum.Current |> should be Null // we return Unchecked.defaultof
@@ -159,10 +159,10 @@ let ``CE taskSeq, MoveNext once too far`` () = task {
     }
 
     let enum = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheck true enum // first item
-    do! moveNextAndCheck true enum // second item
-    do! moveNextAndCheck false enum // third item: false
-    do! moveNextAndCheck false enum // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheck true enum // first item
+    do! Assert.moveNextAndCheck true enum // second item
+    do! Assert.moveNextAndCheck false enum // third item: false
+    do! Assert.moveNextAndCheck false enum // this used to be an error, see issue #39 and PR #42
 }
 
 [<Fact>]
@@ -176,13 +176,13 @@ let ``CE taskSeq, MoveNext too far`` () = task {
     let enum = tskSeq.GetAsyncEnumerator()
 
     // first get past the post
-    do! moveNextAndCheck true enum // first item
-    do! moveNextAndCheck true enum // second item
-    do! moveNextAndCheck false enum // third item: false
+    do! Assert.moveNextAndCheck true enum // first item
+    do! Assert.moveNextAndCheck true enum // second item
+    do! Assert.moveNextAndCheck false enum // third item: false
 
     // then call it bunch of times to ensure we don't get an InvalidOperationException, see issue #39 and PR #42
     for i in 0..100 do
-        do! moveNextAndCheck false enum
+        do! Assert.moveNextAndCheck false enum
 
     // after whatever amount of time MoveNextAsync, we can still safely call Current
     enum.Current |> should equal Guid.Empty // we return Unchecked.defaultof, which is Guid.Empty for guids
@@ -199,16 +199,16 @@ let ``CE taskSeq, call GetAsyncEnumerator twice, both should have equal behavior
     let enum2 = tskSeq.GetAsyncEnumerator()
 
     // enum1
-    do! moveNextAndCheckCurrent true 1 enum1 // first item
-    do! moveNextAndCheckCurrent true 2 enum1 // second item
-    do! moveNextAndCheckCurrent false 0 enum1 // third item: false
-    do! moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheckCurrent true 1 enum1 // first item
+    do! Assert.moveNextAndCheckCurrent true 2 enum1 // second item
+    do! Assert.moveNextAndCheckCurrent false 0 enum1 // third item: false
+    do! Assert.moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
 
     // enum2
-    do! moveNextAndCheckCurrent true 1 enum2 // first item
-    do! moveNextAndCheckCurrent true 2 enum2 // second item
-    do! moveNextAndCheckCurrent false 0 enum2 // third item: false
-    do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheckCurrent true 1 enum2 // first item
+    do! Assert.moveNextAndCheckCurrent true 2 enum2 // second item
+    do! Assert.moveNextAndCheckCurrent false 0 enum2 // third item: false
+    do! Assert.moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
 [<Fact>]
@@ -223,16 +223,16 @@ let ``CE seq -- comparison --, call GetEnumerator twice`` () = task {
     let enum2 = sq.GetEnumerator()
 
     // enum1
-    do seqMoveNextAndCheckCurrent true 1 enum1 // first item
-    do seqMoveNextAndCheckCurrent true 2 enum1 // second item
-    do seqMoveNextAndCheckCurrent false 0 enum1 // third item: false
-    do seqMoveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
+    do Assert.seqMoveNextAndCheckCurrent true 1 enum1 // first item
+    do Assert.seqMoveNextAndCheckCurrent true 2 enum1 // second item
+    do Assert.seqMoveNextAndCheckCurrent false 0 enum1 // third item: false
+    do Assert.seqMoveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
 
     // enum2
-    do seqMoveNextAndCheckCurrent true 1 enum2 // first item
-    do seqMoveNextAndCheckCurrent true 2 enum2 // second item
-    do seqMoveNextAndCheckCurrent false 0 enum2 // third item: false
-    do seqMoveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
+    do Assert.seqMoveNextAndCheckCurrent true 1 enum2 // first item
+    do Assert.seqMoveNextAndCheckCurrent true 2 enum2 // second item
+    do Assert.seqMoveNextAndCheckCurrent false 0 enum2 // third item: false
+    do Assert.seqMoveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
 
@@ -247,17 +247,17 @@ let ``CE taskSeq, cal GetAsyncEnumerator twice -- in lockstep`` () = task {
     let enum2 = tskSeq.GetAsyncEnumerator()
 
     // enum1 & enum2 in lock step
-    do! moveNextAndCheckCurrent true 1 enum1 // first item
-    do! moveNextAndCheckCurrent true 1 enum2 // first item
+    do! Assert.moveNextAndCheckCurrent true 1 enum1 // first item
+    do! Assert.moveNextAndCheckCurrent true 1 enum2 // first item
 
-    do! moveNextAndCheckCurrent true 2 enum1 // second item
-    do! moveNextAndCheckCurrent true 2 enum2 // second item
+    do! Assert.moveNextAndCheckCurrent true 2 enum1 // second item
+    do! Assert.moveNextAndCheckCurrent true 2 enum2 // second item
 
-    do! moveNextAndCheckCurrent false 0 enum1 // third item: false
-    do! moveNextAndCheckCurrent false 0 enum2 // third item: false
+    do! Assert.moveNextAndCheckCurrent false 0 enum1 // third item: false
+    do! Assert.moveNextAndCheckCurrent false 0 enum2 // third item: false
 
-    do! moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
-    do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
 [<Fact>]
@@ -269,17 +269,17 @@ let ``CE taskSeq, call GetAsyncEnumerator twice -- after full iteration`` () = t
 
     // enum1
     let enum1 = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheckCurrent true 1 enum1 // first item
-    do! moveNextAndCheckCurrent true 2 enum1 // second item
-    do! moveNextAndCheckCurrent false 0 enum1 // third item: false
-    do! moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheckCurrent true 1 enum1 // first item
+    do! Assert.moveNextAndCheckCurrent true 2 enum1 // second item
+    do! Assert.moveNextAndCheckCurrent false 0 enum1 // third item: false
+    do! Assert.moveNextAndCheckCurrent false 0 enum1 // this used to be an error, see issue #39 and PR #42
 
     // enum2
     let enum2 = tskSeq.GetAsyncEnumerator()
-    do! moveNextAndCheckCurrent true 1 enum2 // first item
-    do! moveNextAndCheckCurrent true 2 enum2 // second item
-    do! moveNextAndCheckCurrent false 0 enum2 // third item: false
-    do! moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
+    do! Assert.moveNextAndCheckCurrent true 1 enum2 // first item
+    do! Assert.moveNextAndCheckCurrent true 2 enum2 // second item
+    do! Assert.moveNextAndCheckCurrent false 0 enum2 // third item: false
+    do! Assert.moveNextAndCheckCurrent false 0 enum2 // this used to be an error, see issue #39 and PR #42
 }
 
 [<Fact>]
@@ -294,7 +294,7 @@ let ``CE taskSeq, call GetAsyncEnumerator twice -- random mixed iteration`` () =
     let enum1 = tskSeq.GetAsyncEnumerator()
 
     // move #1
-    do! moveNextAndCheckCurrent true 1 enum1 // first item
+    do! Assert.moveNextAndCheckCurrent true 1 enum1 // first item
 
     // enum2
     let enum2 = tskSeq.GetAsyncEnumerator()
@@ -302,37 +302,37 @@ let ``CE taskSeq, call GetAsyncEnumerator twice -- random mixed iteration`` () =
     enum2.Current |> should equal 0 // should be at default location
 
     // move #2
-    do! moveNextAndCheckCurrent true 1 enum2
+    do! Assert.moveNextAndCheckCurrent true 1 enum2
     enum1.Current |> should equal 1
     enum2.Current |> should equal 1
 
     // move #2
-    do! moveNextAndCheckCurrent true 2 enum2
+    do! Assert.moveNextAndCheckCurrent true 2 enum2
     enum1.Current |> should equal 1
     enum2.Current |> should equal 2
 
     // move #1
-    do! moveNextAndCheckCurrent true 2 enum1
+    do! Assert.moveNextAndCheckCurrent true 2 enum1
     enum1.Current |> should equal 2
     enum2.Current |> should equal 2
 
     // move #1
-    do! moveNextAndCheckCurrent true 3 enum1
+    do! Assert.moveNextAndCheckCurrent true 3 enum1
     enum1.Current |> should equal 3
     enum2.Current |> should equal 2
 
     // move #1
-    do! moveNextAndCheckCurrent false 0 enum1
+    do! Assert.moveNextAndCheckCurrent false 0 enum1
     enum1.Current |> should equal 0
     enum2.Current |> should equal 2
 
     // move #2
-    do! moveNextAndCheckCurrent true 3 enum2
+    do! Assert.moveNextAndCheckCurrent true 3 enum2
     enum1.Current |> should equal 0
     enum2.Current |> should equal 3
 
     // move #2
-    do! moveNextAndCheckCurrent false 0 enum2
+    do! Assert.moveNextAndCheckCurrent false 0 enum2
     enum1.Current |> should equal 0
 }
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.Other.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.Other.fs
@@ -78,7 +78,7 @@ let ``TaskSeq-isEmpty returns false for non-empty`` () = task {
 [<Fact>]
 let ``TaskSeq-isEmpty returns false for delayed non-empty sequence`` () = task {
     let! isEmpty =
-        createLongerDummyTaskSeq 200<ms> 400<ms> 3
+        Gen.sideEffectTaskSeqMs 200<ms> 400<ms> 3
         |> TaskSeq.isEmpty
 
     isEmpty |> should be False

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.Other.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.Other.fs
@@ -77,9 +77,7 @@ let ``TaskSeq-isEmpty returns false for non-empty`` () = task {
 
 [<Fact>]
 let ``TaskSeq-isEmpty returns false for delayed non-empty sequence`` () = task {
-    let! isEmpty =
-        Gen.sideEffectTaskSeqMs 200<ms> 400<ms> 3
-        |> TaskSeq.isEmpty
+    let! isEmpty = Gen.sideEffectTaskSeqMs 200<ms> 400<ms> 3 |> TaskSeq.isEmpty
 
     isEmpty |> should be False
 }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
@@ -22,14 +22,14 @@ open System.Collections.Generic
 
 [<Fact>]
 let ``TaskSeq-toArrayAsync should succeed`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let! (results: _[]) = tq |> TaskSeq.toArrayAsync
     results |> should equal [| 1..10 |]
 }
 
 [<Fact>]
 let ``TaskSeq-toArrayAsync can be applied multiple times to the same sequence`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let! (results1: _[]) = tq |> TaskSeq.toArrayAsync
     let! (results2: _[]) = tq |> TaskSeq.toArrayAsync
     let! (results3: _[]) = tq |> TaskSeq.toArrayAsync
@@ -42,46 +42,46 @@ let ``TaskSeq-toArrayAsync can be applied multiple times to the same sequence`` 
 
 [<Fact>]
 let ``TaskSeq-toListAsync should succeed`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let! (results: list<_>) = tq |> TaskSeq.toListAsync
     results |> should equal [ 1..10 ]
 }
 
 [<Fact>]
 let ``TaskSeq-toSeqCachedAsync should succeed`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let! (results: seq<_>) = tq |> TaskSeq.toSeqCachedAsync
     results |> Seq.toArray |> should equal [| 1..10 |]
 }
 
 [<Fact>]
 let ``TaskSeq-toIListAsync should succeed`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let! (results: IList<_>) = tq |> TaskSeq.toIListAsync
     results |> Seq.toArray |> should equal [| 1..10 |]
 }
 
 [<Fact>]
 let ``TaskSeq-toResizeArray should succeed`` () = task {
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let! (results: ResizeArray<_>) = tq |> TaskSeq.toResizeArrayAsync
     results |> Seq.toArray |> should equal [| 1..10 |]
 }
 
 [<Fact>]
 let ``TaskSeq-toArray should succeed and be blocking`` () =
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let (results: _[]) = tq |> TaskSeq.toArray
     results |> should equal [| 1..10 |]
 
 [<Fact>]
 let ``TaskSeq-toList should succeed and be blocking`` () =
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let (results: list<_>) = tq |> TaskSeq.toList
     results |> should equal [ 1..10 ]
 
 [<Fact>]
 let ``TaskSeq-toSeqCached should succeed and be blocking`` () =
-    let tq = createDummyTaskSeq 10
+    let tq = Gen.sideEffectTaskSeq 10
     let (results: seq<_>) = tq |> TaskSeq.toSeqCached
     results |> Seq.toArray |> should equal [| 1..10 |]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
@@ -9,8 +9,8 @@ open FSharpy
 
 [<Fact>]
 let ``TaskSeq-zip zips in correct order`` () = task {
-    let one = createDummyTaskSeq 10
-    let two = createDummyTaskSeq 10
+    let one = Gen.sideEffectTaskSeq 10
+    let two = Gen.sideEffectTaskSeq 10
     let combined = TaskSeq.zip one two
     let! combined = TaskSeq.toArrayAsync combined
 
@@ -26,8 +26,8 @@ let ``TaskSeq-zip zips in correct order`` () = task {
 
 [<Fact>]
 let ``TaskSeq-zip zips in correct order for differently delayed sequences`` () = task {
-    let one = createDummyDirectTaskSeq 10
-    let two = createDummyTaskSeq 10
+    let one = Gen.sideEffectTaskSeq_Sequential 10
+    let two = Gen.sideEffectTaskSeq 10
     let combined = TaskSeq.zip one two
     let! combined = TaskSeq.toArrayAsync combined
 
@@ -43,8 +43,8 @@ let ``TaskSeq-zip zips in correct order for differently delayed sequences`` () =
 
 [<Theory; InlineData 100; InlineData 1_000; InlineData 10_000; InlineData 100_000>]
 let ``TaskSeq-zip zips large sequences just fine`` length = task {
-    let one = createDummyTaskSeqWith 10L<µs> 50L<µs> length
-    let two = createDummyDirectTaskSeq length
+    let one = Gen.sideEffectTaskSeqMicro 10L<µs> 50L<µs> length
+    let two = Gen.sideEffectTaskSeq_Sequential length
     let combined = TaskSeq.zip one two
     let! combined = TaskSeq.toArrayAsync combined
 
@@ -76,8 +76,8 @@ let ``TaskSeq-zip zips different types`` () = task {
 
 [<Theory; InlineData true; InlineData false>]
 let ``TaskSeq-zip throws on unequal lengths, variant`` leftThrows = task {
-    let long = createDummyTaskSeq 11
-    let short = createDummyTaskSeq 10
+    let long = Gen.sideEffectTaskSeq 11
+    let short = Gen.sideEffectTaskSeq 10
 
     let combined =
         if leftThrows then
@@ -91,7 +91,7 @@ let ``TaskSeq-zip throws on unequal lengths, variant`` leftThrows = task {
 
 [<Theory; InlineData true; InlineData false>]
 let ``TaskSeq-zip throws on unequal lengths with empty seq`` leftThrows = task {
-    let one = createDummyTaskSeq 1
+    let one = Gen.sideEffectTaskSeq 1
 
     let combined =
         if leftThrows then

--- a/src/FSharpy.TaskSeq.Test/TestUtils.fs
+++ b/src/FSharpy.TaskSeq.Test/TestUtils.fs
@@ -461,10 +461,10 @@ module TestUtils =
             | SeqWithSideEffect.Sequential_Combine -> taskSeq {
                 do i <- i + 1
                 yield! [ i .. i + 4 ]
-                do i <- i + 4
+                do i <- i + 5
                 yield i
                 do i <- i + 1
-                yield! seq { i .. i + 4 }
+                yield! seq { i .. i + 3 }
                 i <- 10 // ensure we inc 'i' to 10 for a potential next iteration
               }
 

--- a/src/FSharpy.TaskSeq.Test/TestUtils.fs
+++ b/src/FSharpy.TaskSeq.Test/TestUtils.fs
@@ -470,7 +470,7 @@ module TestUtils =
 
             | SeqWithSideEffect.Sequential_Zero -> taskSeq {
                 if inc &i % 10 = 1 then // always true UNLESS NOT FULLY EVALUATED!!!
-                    yield! [ 1..3 ]
+                    yield! [ i .. i + 2 ]
                 // absent 'else' triggers CE.Zero
 
                 if inc &i = -24 then // never true

--- a/src/FSharpy.TaskSeq.Test/TestUtils.fs
+++ b/src/FSharpy.TaskSeq.Test/TestUtils.fs
@@ -465,11 +465,11 @@ module TestUtils =
                 yield i
                 do i <- i + 1
                 yield! seq { i .. i + 3 }
-                i <- 10 // ensure we inc 'i' to 10 for a potential next iteration
+                i <- i + 3 // ensure we inc 'i' to 10 for a potential next iteration
               }
 
             | SeqWithSideEffect.Sequential_Zero -> taskSeq {
-                if inc &i = 1 then
+                if inc &i % 10 = 1 then // always true UNLESS NOT FULLY EVALUATED!!!
                     yield! [ 1..3 ]
                 // absent 'else' triggers CE.Zero
 


### PR DESCRIPTION
Basically as in the title. We now have these sequences, each returning either an empty sequence variant, or a sequence `1..10`, either with mutable data on each enumeration, using byref data, plain old mutable, or let bindings, using spin delays or thread-yielding delays, or deeply nested `taskSeq`.

These types work with `Theory` and `ClassData`. Just pass it this class name:

```f#
    type TestEmptyVariants() as this =
        inherit TheoryData<EmptyVariant>()

        do
            this.Add EmptyVariant.CallEmpty
            this.Add EmptyVariant.Do
            this.Add EmptyVariant.DoBang
            this.Add EmptyVariant.YieldBang
            this.Add EmptyVariant.YieldBangNested
            this.Add EmptyVariant.DelayDoBang
            this.Add EmptyVariant.DelayYieldBang
            this.Add EmptyVariant.DelayYieldBangNested

    type TestImmTaskSeq() as this =
        inherit TheoryData<SeqImmutable>()

        do
            this.Add SeqImmutable.Sequential_YieldBang
            this.Add SeqImmutable.Sequential_Yield
            this.Add SeqImmutable.Sequential_For
            this.Add SeqImmutable.Sequential_Combine
            this.Add SeqImmutable.Sequential_Zero
            this.Add SeqImmutable.ThreadSpinWait
            this.Add SeqImmutable.AsyncYielded
            this.Add SeqImmutable.AsyncYielded_Nested

    type TestSideEffectTaskSeq() as this =
        inherit TheoryData<SeqWithSideEffect>()

        do
            this.Add SeqWithSideEffect.Sequential_YieldBang
            this.Add SeqWithSideEffect.Sequential_Yield
            this.Add SeqWithSideEffect.Sequential_For
            this.Add SeqWithSideEffect.Sequential_Combine
            this.Add SeqWithSideEffect.Sequential_Zero
            this.Add SeqWithSideEffect.ThreadSpinWait
            this.Add SeqWithSideEffect.AsyncYielded
            this.Add SeqWithSideEffect.AsyncYielded_Nested
```