### PR TITLE
Remove ReturnFrom and with it, the `return!`-enabled tailcalls

### DIFF
--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
@@ -111,21 +111,6 @@ let ``CE taskSeq with nested deeply yield! perf test 8521 nested tasks`` () = ta
 }
 
 [<Fact>]
-let ``CE taskSeq with several return!`` () = task {
-    // TODO: should we even support this? Traditional 'seq' doesn't.
-    let tskSeq = taskSeq {
-        return! Gen.sideEffectTaskSeq 10
-        return! Gen.sideEffectTaskSeq 5
-    }
-
-    let! data = tskSeq |> TaskSeq.toListAsync
-
-    // FIXME!!! This behavior is *probably* not correct
-    data |> should equal [ 1..10 ]
-}
-
-
-[<Fact>]
 let ``CE taskSeq with mixing yield! and yield`` () = task {
     let tskSeq = taskSeq {
         yield! Gen.sideEffectTaskSeq 10


### PR DESCRIPTION
As in the title. 
We should look into tailcalling `yield!` instead, if we want to support this. Right now, it's "out of scope" while we're working on stabilizing the resumable code implementation.

@dsyme, I think this is basically it. Anything I missed?