### PR TITLE
Make logging conditional for debug builds only, add `Conditional "DEBUG"`

### DIFF
--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -1,5 +1,7 @@
 namespace FSharpy.TaskSeqBuilders
 
+open System.Diagnostics
+
 #nowarn "57" // note: this is *not* an experimental feature, but they forgot to switch off the flag
 
 open System
@@ -32,6 +34,20 @@ module Internal = // cannot be marked with 'internal' scope
 
         with _ ->
             false
+
+    type Debug =
+
+        [<Conditional("DEBUG")>]
+        static member private print value =
+            // don't use ksprintf here, because the compiler does not remove all allocations due to
+            // the way PrintfFormat types are compiled, even if we set the Conditional attribute.
+            printfn "%i (%b): %s" Thread.CurrentThread.ManagedThreadId Thread.CurrentThread.IsThreadPoolThread value
+
+        [<Conditional("DEBUG")>]
+        static member logInfo(str) = Debug.print str
+
+        [<Conditional("DEBUG")>]
+        static member logInfo(str, data) = Debug.print $"%s{str}{data}"
 
     let log format =
         if verbose then


### PR DESCRIPTION
As in the title. This allows us to keep the logging in the project for a while, until we are confident enough that we can live without it. 

The `[<Conditional "DEBUG">]`, which only applies to members returning `unit` (which makes it impossible to use with `kprintf`), will leave the member code in, but none of the call-sites will be compiled in Release mode, in other words, it erases all `log` statements from the codebase for package building and the like.