### PR TITLE
Expand testdata tests across the board, add bunch of tests

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas": {
+      "version": "5.0.6",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
+++ b/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
@@ -26,10 +26,10 @@
     <Compile Include="TaskSeq.Last.Tests.fs" />
     <Compile Include="TaskSeq.Length.Tests.fs" />
     <Compile Include="TaskSeq.Map.Tests.fs" />
-    <Compile Include="TaskSeq.Pick.Tests.fs" />
-    <Compile Include="TaskSeq.Zip.Tests.fs" />
-    <Compile Include="TaskSeq.ToXXX.Tests.fs" />
     <Compile Include="TaskSeq.OfXXX.Tests.fs" />
+    <Compile Include="TaskSeq.Pick.Tests.fs" />
+    <Compile Include="TaskSeq.ToXXX.Tests.fs" />
+    <Compile Include="TaskSeq.Zip.Tests.fs" />
     <Compile Include="TaskSeq.Tests.CE.fs" />
     <Compile Include="TaskSeq.StateTransitionBug.Tests.CE.fs" />
     <Compile Include="TaskSeq.StateTransitionBug-delayed.Tests.CE.fs" />

--- a/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
+++ b/src/FSharpy.TaskSeq.Test/FSharpy.TaskSeq.Test.fsproj
@@ -14,11 +14,13 @@
     <Compile Include="TestUtils.fs" />
     <Compile Include="TaskSeq.Choose.Tests.fs" />
     <Compile Include="TaskSeq.Collect.Tests.fs" />
+    <Compile Include="TaskSeq.Empty.Tests.fs" />
     <Compile Include="TaskSeq.ExactlyOne.Tests.fs" />
     <Compile Include="TaskSeq.Filter.Tests.fs" />
     <Compile Include="TaskSeq.Find.Tests.fs" />
     <Compile Include="TaskSeq.Fold.Tests.fs" />
     <Compile Include="TaskSeq.Head.Tests.fs" />
+    <Compile Include="TaskSeq.IsEmpty.fs" />
     <Compile Include="TaskSeq.Item.Tests.fs" />
     <Compile Include="TaskSeq.Iter.Tests.fs" />
     <Compile Include="TaskSeq.Last.Tests.fs" />
@@ -28,7 +30,6 @@
     <Compile Include="TaskSeq.Zip.Tests.fs" />
     <Compile Include="TaskSeq.ToXXX.Tests.fs" />
     <Compile Include="TaskSeq.OfXXX.Tests.fs" />
-    <Compile Include="TaskSeq.Tests.Other.fs" />
     <Compile Include="TaskSeq.Tests.CE.fs" />
     <Compile Include="TaskSeq.StateTransitionBug.Tests.CE.fs" />
     <Compile Include="TaskSeq.StateTransitionBug-delayed.Tests.CE.fs" />

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
@@ -9,6 +9,13 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+//
+// TaskSeq.map
+// TaskSeq.mapi
+// TaskSeq.mapAsync
+// TaskSeq.mapiAsync
+//
+
 module EmptySeq =
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-choose`` variant = task {

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
@@ -58,7 +58,7 @@ module EmptySeq =
         |> TaskSeq.collectAsync (fun _ -> task { return taskSeq { yield 10 } })
         |> verifyEmpty
 
-    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-collectSeq collecting emptiness`` variant =
         Gen.getSeqWithSideEffect variant
         |> TaskSeq.collectSeq (fun _ -> Seq.empty<int>)

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
@@ -6,124 +6,155 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
-let validateSequence sequence =
-    sequence
-    |> Seq.map string
-    |> String.concat ""
-    |> should equal "ABBCCDDEEFFGGHHIIJJK"
 
-[<Fact>]
-let ``TaskSeq-collect operates in correct order`` () = task {
-    let! sq =
+module EmptySeq =
+    let verifyEmpty ts =
+        ts
+        |> TaskSeq.toSeqCachedAsync
+        |> Task.map (Seq.isEmpty >> should be True)
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-collect collecting emptiness`` variant =
         Gen.sideEffectTaskSeq 10
+        |> TaskSeq.collect (fun _ -> Gen.getEmptyVariant variant)
+        |> verifyEmpty
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-collect collecting emptiness v2`` variant =
+        Gen.sideEffectTaskSeq variant
+        |> TaskSeq.collect (fun _ -> Gen.getEmptyVariant EmptyVariant.YieldBang)
+        |> verifyEmpty
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-collect collecting emptiness from emptiness`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.collect (fun _ -> Gen.getEmptyVariant variant)
+        |> verifyEmpty
+
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-collect collecting non-empty sequences on an empty sequence`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.collect (fun _ -> taskSeq { yield 10 })
+        |> verifyEmpty
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-collectAsync collecting emptiness`` variant =
+        Gen.sideEffectTaskSeq 10
+        |> TaskSeq.collectAsync (fun _ -> task { return Gen.getEmptyVariant variant })
+        |> verifyEmpty
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-collectAsync collecting emptiness v2`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.collectAsync (fun _ -> task { return Gen.getEmptyVariant EmptyVariant.DelayDoBang })
+        |> verifyEmpty
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-collectAsync collecting emptiness from emptiness`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.collectAsync (fun _ -> task { return Gen.getEmptyVariant variant })
+        |> verifyEmpty
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-collectAsync collecting non-empty sequences on an empty sequence`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.collectAsync (fun _ -> task { return taskSeq { yield 10 } })
+        |> verifyEmpty
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-collectSeq collecting emptiness`` variant =
+        Gen.getSeqWithSideEffect variant
+        |> TaskSeq.collectSeq (fun _ -> Seq.empty<int>)
+        |> verifyEmpty
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-collectSeq collecting emptiness from emptiness`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.collectSeq (fun _ -> Seq.empty<int>)
+        |> verifyEmpty
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-collectSeq collecting non-empty sequences on an empty sequence`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.collectSeq (fun _ -> seq { yield 10 })
+        |> verifyEmpty
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-collectSeqAsync collecting emptiness`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.collectSeqAsync (fun _ -> task { return Array.empty<int> })
+        |> verifyEmpty
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-collectSeqAsync collecting emptiness from emptiness`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.collectSeqAsync (fun _ -> task { return Array.empty<int> })
+        |> verifyEmpty
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-collectSeqAsync collecting non-empty sequences on an empty sequence`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.collectSeqAsync (fun _ -> task { return [ 10 ] })
+        |> verifyEmpty
+
+module Immutable =
+
+    let validateSequence ts =
+        ts
+        |> TaskSeq.toSeqCachedAsync
+        |> Task.map (Seq.map string)
+        |> Task.map (String.concat "")
+        |> Task.map (should equal "ABBCCDDEEFFGGHHIIJJK")
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-collect operates in correct order`` variant =
+        Gen.getSeqImmutable variant
         |> TaskSeq.collect (fun item -> taskSeq {
             yield char (item + 64)
             yield char (item + 65)
         })
-        |> TaskSeq.toSeqCachedAsync
+        |> validateSequence
 
-    validateSequence sq
-}
-
-[<Fact>]
-let ``TaskSeq-collectAsync operates in correct order`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-collectAsync operates in correct order`` variant =
+        Gen.getSeqImmutable variant
         |> TaskSeq.collectAsync (fun item -> task {
             return taskSeq {
                 yield char (item + 64)
                 yield char (item + 65)
             }
         })
-        |> TaskSeq.toSeqCachedAsync
+        |> validateSequence
 
-    validateSequence sq
-}
-
-[<Fact>]
-let ``TaskSeq-collectSeq operates in correct order`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-collectSeq operates in correct order`` variant =
+        Gen.getSeqImmutable variant
         |> TaskSeq.collectSeq (fun item -> seq {
             yield char (item + 64)
             yield char (item + 65)
         })
-        |> TaskSeq.toSeqCachedAsync
+        |> validateSequence
 
-    validateSequence sq
-}
-
-[<Fact>]
-let ``TaskSeq-collectSeq with arrays operates in correct order`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-collectSeq with arrays operates in correct order`` variant =
+        Gen.getSeqImmutable variant
         |> TaskSeq.collectSeq (fun item -> [| char (item + 64); char (item + 65) |])
-        |> TaskSeq.toArrayAsync
+        |> validateSequence
 
-    validateSequence sq
-}
-
-[<Fact>]
-let ``TaskSeq-collectSeqAsync operates in correct order`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-collectSeqAsync operates in correct order`` variant =
+        Gen.getSeqImmutable variant
         |> TaskSeq.collectSeqAsync (fun item -> task {
             return seq {
                 yield char (item + 64)
                 yield char (item + 65)
             }
         })
-        |> TaskSeq.toSeqCachedAsync
+        |> validateSequence
 
-    validateSequence sq
-}
-
-[<Fact>]
-let ``TaskSeq-collectSeqAsync with arrays operates in correct order`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-collectSeqAsync with arrays operates in correct order`` variant =
+        Gen.getSeqImmutable variant
         |> TaskSeq.collectSeqAsync (fun item -> task { return [| char (item + 64); char (item + 65) |] })
-        |> TaskSeq.toArrayAsync
-
-    validateSequence sq
-}
-
-[<Fact>]
-let ``TaskSeq-collect with empty task sequences`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
-        |> TaskSeq.collect (fun _ -> TaskSeq.ofSeq Seq.empty)
-        |> TaskSeq.toSeqCachedAsync
-
-    Seq.isEmpty sq |> should be True
-}
-
-[<Fact>]
-let ``TaskSeq-collectAsync with empty task sequences`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
-        |> TaskSeq.collectAsync (fun _ -> task { return TaskSeq.empty<string> })
-        |> TaskSeq.toSeqCachedAsync
-
-    Seq.isEmpty sq |> should be True
-}
-
-[<Fact>]
-let ``TaskSeq-collectSeq with empty sequences`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
-        |> TaskSeq.collectSeq (fun _ -> Seq.empty<int>)
-        |> TaskSeq.toSeqCachedAsync
-
-    Seq.isEmpty sq |> should be True
-}
-
-[<Fact>]
-let ``TaskSeq-collectSeqAsync with empty sequences`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
-        |> TaskSeq.collectSeqAsync (fun _ -> task { return Array.empty<int> })
-        |> TaskSeq.toSeqCachedAsync
-
-    Seq.isEmpty sq |> should be True
-}
+        |> validateSequence

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
@@ -8,10 +8,6 @@ open FSharpy
 
 
 module EmptySeq =
-    let verifyEmpty ts =
-        ts
-        |> TaskSeq.toSeqCachedAsync
-        |> Task.map (Seq.isEmpty >> should be True)
 
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-collect collecting emptiness`` variant =

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
@@ -6,6 +6,10 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+//
+// TaskSeq.collect
+// TaskSeq.collectAsync
+//
 
 module EmptySeq =
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Empty.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Empty.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.``Other functions``
+module FSharpy.Tests.Empty
 
 open System.Threading.Tasks
 open Xunit
@@ -61,23 +61,4 @@ let ``TaskSeq-empty multiple times in a taskSeq context`` () = task {
         |> TaskSeq.toArrayAsync
 
     Array.isEmpty sq |> should be True
-}
-
-[<Fact>]
-let ``TaskSeq-isEmpty returns true for empty`` () = task {
-    let! isEmpty = TaskSeq.empty<string> |> TaskSeq.isEmpty
-    isEmpty |> should be True
-}
-
-[<Fact>]
-let ``TaskSeq-isEmpty returns false for non-empty`` () = task {
-    let! isEmpty = taskSeq { yield 42 } |> TaskSeq.isEmpty
-    isEmpty |> should be False
-}
-
-[<Fact>]
-let ``TaskSeq-isEmpty returns false for delayed non-empty sequence`` () = task {
-    let! isEmpty = Gen.sideEffectTaskSeqMs 200<ms> 400<ms> 3 |> TaskSeq.isEmpty
-
-    isEmpty |> should be False
 }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
@@ -7,6 +7,11 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+//
+// TaskSeq.exactlyOne
+// TaskSeq.tryExactlyOne
+//
+
 module EmptySeq =
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-exactlyOne throws`` variant = task {

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
@@ -7,93 +7,166 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+module EmptySeq =
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-exactlyOne throws`` variant = task {
+        fun () ->
+            Gen.getEmptyVariant variant
+            |> TaskSeq.exactlyOne
+            |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
 
-[<Fact>]
-let ``TaskSeq-exactlyOne throws on empty sequences`` () = task {
-    fun () -> TaskSeq.empty<string> |> TaskSeq.exactlyOne |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-tryExactlyOne returns None`` variant = task {
+        let! nothing = Gen.getEmptyVariant variant |> TaskSeq.tryExactlyOne
+        nothing |> should be None'
+    }
 
-[<Fact>]
-let ``TaskSeq-exactlyOne throws on empty sequences - variant`` () = task {
-    fun () -> taskSeq { do () } |> TaskSeq.exactlyOne |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+module Other =
+    [<Fact>]
+    let ``TaskSeq-exactlyOne throws for a sequence of length = two`` () = task {
+        fun () ->
+            taskSeq {
+                yield 1
+                yield 2
+            }
+            |> TaskSeq.exactlyOne
+            |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
 
-[<Fact>]
-let ``TaskSeq-tryExactlyOne returns None on empty sequences`` () = task {
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryExactlyOne
-    nothing |> should be None'
-}
+    [<Fact>]
+    let ``TaskSeq-exactlyOne throws for a sequence of length = two - variant`` () = task {
+        fun () ->
+            Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 2
+            |> TaskSeq.exactlyOne
+            |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
 
-[<Fact>]
-let ``TaskSeq-exactlyOne throws for a sequence of length = two`` () = task {
-    fun () ->
+    [<Fact>]
+    let ``TaskSeq-tryExactlyOne returns None for sequence of length = two`` () =
         taskSeq {
             yield 1
             yield 2
         }
-        |> TaskSeq.exactlyOne
-        |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+        |> TaskSeq.tryExactlyOne
+        |> Task.map (should be None')
 
-[<Fact>]
-let ``TaskSeq-exactlyOne throws for a sequence of length = two - variant`` () = task {
-    fun () ->
+    [<Fact>]
+    let ``TaskSeq-tryExactlyOne returns None for sequence of length = two - variant`` () =
         Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 2
-        |> TaskSeq.exactlyOne
-        |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
-
-
-[<Fact>]
-let ``TaskSeq-exactlyOne throws with a larger sequence`` () = task {
-    fun () ->
-        Gen.sideEffectTaskSeqMicro 50L<µs> 300L<µs> 200
-        |> TaskSeq.exactlyOne
-        |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
-
-[<Fact>]
-let ``TaskSeq-tryExactlyOne returns None with a larger sequence`` () = task {
-    let! nothing =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 300L<µs> 20
         |> TaskSeq.tryExactlyOne
+        |> Task.map (should be None')
 
-    nothing |> should be None'
-}
+    [<Fact>]
+    let ``TaskSeq-exactlyOne throws with a larger sequence`` () = task {
+        fun () ->
+            Gen.sideEffectTaskSeqMicro 50L<µs> 300L<µs> 200
+            |> TaskSeq.exactlyOne
+            |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
 
-[<Fact>]
-let ``TaskSeq-exactlyOne gets the only item in a singleton sequence`` () = task {
-    let! exactlyOne = taskSeq { yield 10 } |> TaskSeq.exactlyOne
-    exactlyOne |> should equal 10
-}
+    [<Fact>]
+    let ``TaskSeq-tryExactlyOne returns None with a larger sequence`` () = task {
+        let! nothing =
+            Gen.sideEffectTaskSeqMicro 50L<µs> 300L<µs> 20
+            |> TaskSeq.tryExactlyOne
 
-[<Fact>]
-let ``TaskSeq-tryExactlyOne gets the only item in a singleton sequence`` () = task {
-    let! exactlyOne = taskSeq { yield 10 } |> TaskSeq.tryExactlyOne
-    exactlyOne |> should be Some'
-    exactlyOne |> should equal (Some 10)
-}
+        nothing |> should be None'
+    }
 
-[<Fact>]
-let ``TaskSeq-exactlyOne gets the only item in a singleton sequence - variant`` () = task {
-    let! exactlyOne =
-        Gen.sideEffectTaskSeqMs 50<ms> 300<ms> 1
-        |> TaskSeq.exactlyOne
+    [<Fact>]
+    let ``TaskSeq-exactlyOne gets the only item in a singleton sequence`` () = task {
+        let! exactlyOne = taskSeq { yield 10 } |> TaskSeq.exactlyOne
+        exactlyOne |> should equal 10
+    }
 
-    exactlyOne |> should equal 1
-}
+    [<Fact>]
+    let ``TaskSeq-tryExactlyOne gets the only item in a singleton sequence`` () = task {
+        let! exactlyOne = taskSeq { yield 10 } |> TaskSeq.tryExactlyOne
+        exactlyOne |> should be Some'
+        exactlyOne |> should equal (Some 10)
+    }
 
-[<Fact>]
-let ``TaskSeq-tryExactlyOne gets the only item in a singleton sequence - variant`` () = task {
-    let! exactlyOne =
-        Gen.sideEffectTaskSeqMs 50<ms> 300<ms> 1
-        |> TaskSeq.tryExactlyOne
+    [<Fact>]
+    let ``TaskSeq-exactlyOne gets the only item in a singleton sequence - variant`` () = task {
+        let! exactlyOne =
+            Gen.sideEffectTaskSeqMs 50<ms> 300<ms> 1
+            |> TaskSeq.exactlyOne
 
-    exactlyOne |> should be Some'
-    exactlyOne |> should equal (Some 1)
-}
+        exactlyOne |> should equal 1
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryExactlyOne gets the only item in a singleton sequence - variant`` () = task {
+        let! exactlyOne =
+            Gen.sideEffectTaskSeqMs 50<ms> 300<ms> 1
+            |> TaskSeq.tryExactlyOne
+
+        exactlyOne |> should be Some'
+        exactlyOne |> should equal (Some 1)
+    }
+
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-exactlyOne throws`` variant =
+        fun () ->
+            Gen.getSeqImmutable variant
+            |> TaskSeq.exactlyOne
+            |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryExactlyOne returns None`` variant = task {
+        let ts = Gen.getSeqImmutable variant
+        let! head1 = TaskSeq.tryExactlyOne ts
+        let! head2 = TaskSeq.tryExactlyOne ts
+        head1 |> should be None'
+        head2 |> should be None'
+    }
+
+module SideEffects =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-exactlyOne throws`` variant =
+        fun () ->
+            Gen.getSeqWithSideEffect variant
+            |> TaskSeq.exactlyOne
+            |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-exactlyOne throws, but sequence remains accessible`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+
+        let! nothing = task {
+            try
+                return! TaskSeq.exactlyOne ts
+            with ex ->
+                ex |> should be ofExactType<ArgumentException>
+                return -42
+        }
+
+        nothing |> should equal -42
+
+        // Test that side-effect has executed. Different sequence variants
+        // increase the counter differently but they're never 1
+        let! head1 = TaskSeq.head ts
+        head1 |> should not' (equal 1)
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryExactlyOne returns None`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+        let! head1 = TaskSeq.tryExactlyOne ts
+        let! head2 = TaskSeq.tryExactlyOne ts
+        head1 |> should be None'
+        head2 |> should be None'
+
+        // Test that side-effect has executed. Different sequence variants
+        // increase the counter differently but they're never 1
+        let! head3 = TaskSeq.head ts
+        head3 |> should not' (equal 1)
+    }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
@@ -227,7 +227,7 @@ module SideEffects =
         i |> should equal 3 // last side effect is ALSO executed
     }
 
-    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-exactlyOne throws`` variant =
         fun () ->
             Gen.getSeqWithSideEffect variant
@@ -235,7 +235,7 @@ module SideEffects =
             |> Task.ignore
         |> should throwAsyncExact typeof<ArgumentException>
 
-    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-exactlyOne throws, but sequence remains accessible`` variant = task {
         let ts = Gen.getSeqWithSideEffect variant
 
@@ -255,7 +255,7 @@ module SideEffects =
         head1 |> should not' (equal 1)
     }
 
-    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-tryExactlyOne returns None`` variant = task {
         let ts = Gen.getSeqWithSideEffect variant
         let! head1 = TaskSeq.tryExactlyOne ts

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
@@ -42,7 +42,7 @@ module Immutable =
         |> Task.map (String >> should equal "ABCDE")
 
 module SideEffects =
-    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-filter filters correctly`` variant =
         Gen.getSeqWithSideEffect variant
         |> TaskSeq.filter ((<=) 5) // greater than
@@ -51,7 +51,7 @@ module SideEffects =
         |> TaskSeq.toArrayAsync
         |> Task.map (String >> should equal "EFGHIJ")
 
-    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-filterAsync filters correctly`` variant =
         Gen.getSeqWithSideEffect variant
         |> TaskSeq.filterAsync (fun x -> task { return x <= 5 })

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
@@ -7,6 +7,12 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+//
+// TaskSeq.filter
+// TaskSeq.filterAsync
+//
+
+
 module EmptySeq =
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-filter has no effect`` variant =

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Find.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Find.Tests.fs
@@ -7,241 +7,174 @@ open FsToolkit.ErrorHandling
 open FSharpy
 open System.Collections.Generic
 
-//
-// TaskSeq.find
-// TaskSeq.findAsync
-// the tryXXX versions are at the bottom half
-//
+module EmptySeq =
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-find raises KeyNotFoundException`` variant =
+        fun () ->
+            Gen.getEmptyVariant variant
+            |> TaskSeq.find ((=) 12)
+            |> Task.ignore
+        |> should throwAsyncExact typeof<KeyNotFoundException>
 
-[<Fact>]
-let ``TaskSeq-find on an empty sequence raises KeyNotFoundException`` () = task {
-    fun () -> TaskSeq.empty |> TaskSeq.find ((=) 12) |> Task.ignore
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-[<Fact>]
-let ``TaskSeq-find on an empty sequence raises KeyNotFoundException - variant`` () = task {
-    fun () -> taskSeq { do () } |> TaskSeq.find ((=) 12) |> Task.ignore
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-[<Fact>]
-let ``TaskSeq-findAsync on an empty sequence raises KeyNotFoundException`` () = task {
-    fun () ->
-        TaskSeq.empty
-        |> TaskSeq.findAsync (fun x -> task { return x = 12 })
-        |> Task.ignore
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-[<Fact>]
-let ``TaskSeq-find sad path raises KeyNotFoundException`` () = task {
-    fun () ->
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.find ((=) 0) // dummy tasks sequence starts at 1
-        |> Task.ignore
-
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-[<Fact>]
-let ``TaskSeq-findAsync sad path raises KeyNotFoundException`` () = task {
-    fun () ->
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.findAsync (fun x -> task { return x = 0 }) // dummy tasks sequence starts at 1
-        |> Task.ignore
-
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-[<Fact>]
-let ``TaskSeq-find sad path raises KeyNotFoundException variant`` () = task {
-    fun () ->
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.find ((=) 51) // dummy tasks sequence ends at 50
-        |> Task.ignore
-
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-[<Fact>]
-let ``TaskSeq-findAsync sad path raises KeyNotFoundException variant`` () = task {
-    fun () ->
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.findAsync (fun x -> task { return x = 51 }) // dummy tasks sequence ends at 50
-        |> Task.ignore
-
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-findAsync raises KeyNotFoundException`` variant =
+        fun () ->
+            Gen.getEmptyVariant variant
+            |> TaskSeq.findAsync (fun x -> task { return x = 12 })
+            |> Task.ignore
+        |> should throwAsyncExact typeof<KeyNotFoundException>
 
 
-[<Fact>]
-let ``TaskSeq-find happy path middle of seq`` () = task {
-    let! twentyFive =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.find (fun x -> x < 26 && x > 24)
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-tryFind returns None`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.tryFind ((=) 12)
+        |> Task.map (should be None')
 
-    twentyFive |> should equal 25
-}
-
-[<Fact>]
-let ``TaskSeq-findAsync happy path middle of seq`` () = task {
-    let! twentyFive =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.findAsync (fun x -> task { return x < 26 && x > 24 })
-
-    twentyFive |> should equal 25
-}
-
-[<Fact>]
-let ``TaskSeq-find happy path first item of seq`` () = task {
-    let! first =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.find ((=) 1) // dummy tasks seq starts at 1
-
-    first |> should equal 1
-}
-
-[<Fact>]
-let ``TaskSeq-findAsync happy path first item of seq`` () = task {
-    let! first =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.findAsync (fun x -> task { return x = 1 }) // dummy tasks seq starts at 1
-
-    first |> should equal 1
-}
-
-[<Fact>]
-let ``TaskSeq-find happy path last item of seq`` () = task {
-    let! last =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.find ((=) 50) // dummy tasks seq ends at 50
-
-    last |> should equal 50
-}
-
-[<Fact>]
-let ``TaskSeq-findAsync happy path last item of seq`` () = task {
-    let! last =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.findAsync (fun x -> task { return x = 50 }) // dummy tasks seq ends at 50
-
-    last |> should equal 50
-}
-
-//
-// TaskSeq.tryFind
-// TaskSeq.tryFindAsync
-//
-
-[<Fact>]
-let ``TaskSeq-tryFind on an empty sequence returns None`` () = task {
-    let! nothing = TaskSeq.empty |> TaskSeq.tryFind ((=) 12)
-    nothing |> should be None'
-}
-
-[<Fact>]
-let ``TaskSeq-tryFindAsync on an empty sequence returns None`` () = task {
-    let! nothing =
-        TaskSeq.empty
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-tryFindAsync returns None`` variant =
+        Gen.getEmptyVariant variant
         |> TaskSeq.tryFindAsync (fun x -> task { return x = 12 })
+        |> Task.map (should be None')
 
-    nothing |> should be None'
-}
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-find sad path raises KeyNotFoundException`` variant =
+        fun () ->
+            Gen.getSeqImmutable variant
+            |> TaskSeq.find ((=) 0) // dummy tasks sequence starts at 1
+            |> Task.ignore
 
-[<Fact>]
-let ``TaskSeq-tryFind sad path returns None`` () = task {
-    let! nothing =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFind ((=) 0) // dummy tasks sequence starts at 1
+        |> should throwAsyncExact typeof<KeyNotFoundException>
 
-    nothing |> should be None'
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-findAsync sad path raises KeyNotFoundException`` variant =
+        fun () ->
+            Gen.getSeqImmutable variant
+            |> TaskSeq.findAsync (fun x -> task { return x = 0 }) // dummy tasks sequence starts at 1
+            |> Task.ignore
 
-[<Fact>]
-let ``TaskSeq-tryFindAsync sad path return None`` () = task {
-    let! nothing =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFindAsync (fun x -> task { return x = 0 }) // dummy tasks sequence starts at 1
+        |> should throwAsyncExact typeof<KeyNotFoundException>
 
-    nothing |> should be None'
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-find sad path raises KeyNotFoundException variant`` variant =
+        fun () ->
+            Gen.getSeqImmutable variant
+            |> TaskSeq.find ((=) 11)
+            |> Task.ignore
 
-[<Fact>]
-let ``TaskSeq-tryFind sad path returns None variant`` () = task {
-    let! nothing =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFind ((<=) 51) // dummy tasks sequence ends at 50 (inverted sign in lambda!)
+        |> should throwAsyncExact typeof<KeyNotFoundException>
 
-    nothing |> should be None'
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-findAsync sad path raises KeyNotFoundException variant`` variant =
+        fun () ->
+            Gen.getSeqImmutable variant
+            |> TaskSeq.findAsync (fun x -> task { return x = 11 })
+            |> Task.ignore
 
-[<Fact>]
-let ``TaskSeq-tryFindAsync sad path return None - variant`` () = task {
-    let! nothing =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFindAsync (fun x -> task { return x >= 51 }) // dummy tasks sequence ends at 50
-
-    nothing |> should be None'
-}
+        |> should throwAsyncExact typeof<KeyNotFoundException>
 
 
-[<Fact>]
-let ``TaskSeq-tryFind happy path middle of seq`` () = task {
-    let! twentyFive =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFind (fun x -> x < 26 && x > 24)
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-find happy path middle of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.find (fun x -> x < 6 && x > 4)
+        |> Task.map (should equal 5)
 
-    twentyFive |> should be Some'
-    twentyFive |> should equal (Some 25)
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-findAsync happy path middle of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.findAsync (fun x -> task { return x < 6 && x > 4 })
+        |> Task.map (should equal 5)
 
-[<Fact>]
-let ``TaskSeq-tryFindAsync happy path middle of seq`` () = task {
-    let! twentyFive =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFindAsync (fun x -> task { return x < 26 && x > 24 })
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-find happy path first item of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.find ((=) 1)
+        |> Task.map (should equal 1)
 
-    twentyFive |> should be Some'
-    twentyFive |> should equal (Some 25)
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-findAsync happy path first item of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.findAsync (fun x -> task { return x = 1 })
+        |> Task.map (should equal 1)
 
-[<Fact>]
-let ``TaskSeq-tryFind happy path first item of seq`` () = task {
-    let! first =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFind ((=) 1) // dummy tasks seq starts at 1
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-find happy path last item of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.find ((=) 10)
+        |> Task.map (should equal 10)
 
-    first |> should be Some'
-    first |> should equal (Some 1)
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-findAsync happy path last item of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.findAsync (fun x -> task { return x = 10 }) // dummy tasks seq ends at 50
+        |> Task.map (should equal 10)
 
-[<Fact>]
-let ``TaskSeq-tryFindAsync happy path first item of seq`` () = task {
-    let! first =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFindAsync (fun x -> task { return x = 1 }) // dummy tasks seq starts at 1
 
-    first |> should be Some'
-    first |> should equal (Some 1)
-}
+    //
+    //
+    // tryXXX stuff
+    //      |
+    //      |
+    //      V
 
-[<Fact>]
-let ``TaskSeq-tryFind happy path last item of seq`` () = task {
-    let! last =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFind ((=) 50) // dummy tasks seq ends at 50
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryFind sad path returns None`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.tryFind ((=) 0)
+        |> Task.map (should be None')
 
-    last |> should be Some'
-    last |> should equal (Some 50)
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryFindAsync sad path return None`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.tryFindAsync (fun x -> task { return x = 0 })
+        |> Task.map (should be None')
 
-[<Fact>]
-let ``TaskSeq-tryFindAsync happy path last item of seq`` () = task {
-    let! last =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryFindAsync (fun x -> task { return x = 50 }) // dummy tasks seq ends at 50
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryFind sad path returns None variant`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.tryFind ((<=) 11)
+        |> Task.map (should be None')
 
-    last |> should be Some'
-    last |> should equal (Some 50)
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryFindAsync sad path return None - variant`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.tryFindAsync (fun x -> task { return x >= 11 })
+        |> Task.map (should be None')
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryFind happy path middle of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.tryFind (fun x -> x < 6 && x > 4)
+        |> Task.map (should equal (Some 5))
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryFindAsync happy path middle of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.tryFindAsync (fun x -> task { return x < 6 && x > 4 })
+        |> Task.map (should equal (Some 5))
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryFind happy path first item of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.tryFind ((=) 1)
+        |> Task.map (should equal (Some 1))
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryFindAsync happy path first item of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.tryFindAsync (fun x -> task { return x = 1 })
+        |> Task.map (should equal (Some 1))
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryFind happy path last item of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.tryFind ((=) 10)
+        |> Task.map (should equal (Some 10))
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryFindAsync happy path last item of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.tryFindAsync (fun x -> task { return x = 10 })
+        |> Task.map (should equal (Some 10))

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
@@ -7,43 +7,77 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+module EmptySeq =
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-fold takes state when empty`` variant = task {
+        let! empty =
+            Gen.getEmptyVariant variant
+            |> TaskSeq.fold (fun _ item -> char (item + 64)) '_'
 
-[<Fact>]
-let ``TaskSeq-fold folds with every item`` () = task {
-    let! alphabet =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 26
-        |> TaskSeq.fold (fun (state: StringBuilder) item -> state.Append(char item + '@')) (StringBuilder())
+        empty |> should equal '_'
+    }
 
-    alphabet.ToString()
-    |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-foldAsync takes state when empty`` variant = task {
+        let! alphabet =
+            Gen.getEmptyVariant variant
+            |> TaskSeq.foldAsync (fun _ item -> task { return char (item + 64) }) '_'
 
-[<Fact>]
-let ``TaskSeq-foldAsync folds with every item`` () = task {
-    let! alphabet =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 26
-        |> TaskSeq.foldAsync
-            (fun (state: StringBuilder) item -> task { return state.Append(char item + '@') })
-            (StringBuilder())
+        alphabet |> should equal '_'
+    }
 
-    alphabet.ToString()
-    |> should equal "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-}
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-fold folds with every item`` variant = task {
+        let! letters =
+            (StringBuilder(), Gen.getSeqImmutable variant)
+            ||> TaskSeq.fold (fun state item -> state.Append(char item + '@'))
 
-[<Fact>]
-let ``TaskSeq-fold takes state on empty IAsyncEnumberable`` () = task {
-    let! empty =
-        TaskSeq.empty
-        |> TaskSeq.fold (fun _ item -> char (item + 64)) '_'
+        letters.ToString()
+        |> should equal "ABCDEFGHIJ"
+    }
 
-    empty |> should equal '_'
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-foldAsync folds with every item`` variant = task {
+        let! letters =
+            (StringBuilder(), Gen.getSeqImmutable variant)
+            ||> TaskSeq.foldAsync (fun state item -> task { return state.Append(char item + '@') })
+                
 
-[<Fact>]
-let ``TaskSeq-foldAsync takes state on empty IAsyncEnumerable`` () = task {
-    let! alphabet =
-        TaskSeq.empty
-        |> TaskSeq.foldAsync (fun _ item -> task { return char (item + 64) }) '_'
+        letters.ToString()
+        |> should equal "ABCDEFGHIJ"
+    }
 
-    alphabet |> should equal '_'
-}
+module SideEffects =
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-fold folds with every item, next fold has different state`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+        let! letters =
+            (StringBuilder(), ts)
+            ||> TaskSeq.fold (fun state item -> state.Append(char item + '@'))
+
+        string letters |> should equal "ABCDEFGHIJ"
+
+        let! moreLetters =
+            (letters, ts)
+            ||> TaskSeq.fold (fun state item -> state.Append(char item + '@'))
+
+        string moreLetters |> should equal "ABCDEFGHIJKLMNOPQRST"
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-foldAsync folds with every item, next fold has different state`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+        let! letters =
+            (StringBuilder(), ts)
+            ||> TaskSeq.foldAsync (fun state item -> task { return state.Append(char item + '@') })
+
+        string letters |> should equal "ABCDEFGHIJ"
+
+        let! moreLetters =
+            (letters, ts)
+            ||> TaskSeq.foldAsync (fun state item -> task { return state.Append(char item + '@') })
+
+        string moreLetters |> should equal "ABCDEFGHIJKLMNOPQRST"
+    }
+

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
@@ -7,6 +7,11 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+//
+// TaskSeq.fold
+// TaskSeq.foldAsync
+//
+
 module EmptySeq =
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-fold takes state when empty`` variant = task {
@@ -33,8 +38,7 @@ module Immutable =
             (StringBuilder(), Gen.getSeqImmutable variant)
             ||> TaskSeq.fold (fun state item -> state.Append(char item + '@'))
 
-        letters.ToString()
-        |> should equal "ABCDEFGHIJ"
+        letters.ToString() |> should equal "ABCDEFGHIJ"
     }
 
     [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
@@ -42,16 +46,16 @@ module Immutable =
         let! letters =
             (StringBuilder(), Gen.getSeqImmutable variant)
             ||> TaskSeq.foldAsync (fun state item -> task { return state.Append(char item + '@') })
-                
 
-        letters.ToString()
-        |> should equal "ABCDEFGHIJ"
+
+        letters.ToString() |> should equal "ABCDEFGHIJ"
     }
 
 module SideEffects =
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-fold folds with every item, next fold has different state`` variant = task {
         let ts = Gen.getSeqWithSideEffect variant
+
         let! letters =
             (StringBuilder(), ts)
             ||> TaskSeq.fold (fun state item -> state.Append(char item + '@'))
@@ -68,6 +72,7 @@ module SideEffects =
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-foldAsync folds with every item, next fold has different state`` variant = task {
         let ts = Gen.getSeqWithSideEffect variant
+
         let! letters =
             (StringBuilder(), ts)
             ||> TaskSeq.foldAsync (fun state item -> task { return state.Append(char item + '@') })
@@ -80,4 +85,3 @@ module SideEffects =
 
         string moreLetters |> should equal "ABCDEFGHIJKLMNOPQRST"
     }
-

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
@@ -8,52 +8,172 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 
-[<Fact>]
-let ``TaskSeq-head throws on empty sequences`` () = task {
-    fun () -> TaskSeq.empty<string> |> TaskSeq.head |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+module EmptySeq =
 
-[<Fact>]
-let ``TaskSeq-head throws on empty sequences - variant`` () = task {
-    fun () -> taskSeq { do () } |> TaskSeq.head |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-head throws`` variant = task {
+        fun () -> Gen.getEmptyVariant variant |> TaskSeq.head |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
 
-[<Fact>]
-let ``TaskSeq-tryHead returns None on empty sequences`` () = task {
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryHead
-    nothing |> should be None'
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-tryHead returns None`` variant = task {
+        let! nothing = Gen.getEmptyVariant variant |> TaskSeq.tryHead
+        nothing |> should be None'
+    }
 
-[<Fact>]
-let ``TaskSeq-head gets the first item in a longer sequence`` () = task {
-    let! head =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.head
+    [<Fact>]
+    let ``TaskSeq-head throws, but side effect is executed`` () = task {
+        let mutable x = 0
 
-    head |> should equal 1
-}
+        fun () -> taskSeq { do x <- x + 1 } |> TaskSeq.head |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
 
-[<Fact>]
-let ``TaskSeq-head gets the only item in a singleton sequence`` () = task {
-    let! head = taskSeq { yield 10 } |> TaskSeq.head
-    head |> should equal 10
-}
+        // side effect must have run!
+        x |> should equal 1
+    }
 
-[<Fact>]
-let ``TaskSeq-tryHead gets the first item in a longer sequence`` () = task {
-    let! head =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryHead
 
-    head |> should be Some'
-    head |> should equal (Some 1)
-}
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-head gets the head item of longer sequence`` variant = task {
+        let ts = Gen.getSeqImmutable variant
 
-[<Fact>]
-let ``TaskSeq-tryHead gets the only item in a singleton sequence`` () = task {
-    let! head = taskSeq { yield 10 } |> TaskSeq.tryHead
-    head |> should be Some'
-    head |> should equal (Some 10)
-}
+        let! head = TaskSeq.head ts
+        head |> should equal 1
+
+        let! head = TaskSeq.head ts //immutable, so re-iteration does not change outcome
+        head |> should equal 1
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryHead gets the head item of longer sequence`` variant = task {
+        let ts = Gen.getSeqImmutable variant
+
+        let! head = TaskSeq.tryHead ts
+        head |> should equal (Some 1)
+
+        let! head = TaskSeq.tryHead ts //immutable, so re-iteration does not change outcome
+        head |> should equal (Some 1)
+    }
+
+    [<Fact>]
+    let ``TaskSeq-head gets the only item in a singleton sequence`` () = task {
+        let ts = taskSeq { yield 42 }
+
+        let! head = TaskSeq.head ts
+        head |> should equal 42
+
+        let! head = TaskSeq.head ts // doing it twice is fine
+        head |> should equal 42
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryHead gets the only item in a singleton sequence`` () = task {
+        let ts = taskSeq { yield 42 }
+
+        let! head = TaskSeq.tryHead ts
+        head |> should equal (Some 42)
+
+        let! head = TaskSeq.tryHead ts // doing it twice is fine
+        head |> should equal (Some 42)
+    }
+
+
+module SideEffects =
+    [<Fact>]
+    let ``TaskSeq-head __special-case__ prove it does not read beyond first yield`` () = task {
+        let mutable x = 42
+
+        let one = taskSeq {
+            yield x
+            x <- x + 1 // we never get here
+        }
+
+        let! fortytwo = one |> TaskSeq.head
+        let! stillFortyTwo = one |> TaskSeq.head // the statement after 'yield' will never be reached
+
+        fortytwo |> should equal 42
+        stillFortyTwo |> should equal 42
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryHead __special-case__ prove it does not read beyond first yield`` () = task {
+        let mutable x = 42
+
+        let one = taskSeq {
+            yield x
+            x <- x + 1 // we never get here
+        }
+
+        let! fortytwo = one |> TaskSeq.tryHead
+        fortytwo |> should equal (Some 42)
+
+         // the statement after 'yield' will never be reached, the mutable will not be updated
+        let! stillFortyTwo = one |> TaskSeq.tryHead
+        stillFortyTwo |> should equal (Some 42)
+
+    }
+
+    [<Fact>]
+    let ``TaskSeq-head __special-case__ prove early side effect is executed`` () = task {
+        let mutable x = 42
+
+        let one = taskSeq {
+            x <- x + 1
+            x <- x + 1
+            yield 42
+            x <- x + 200  // we won't get here!
+        }
+
+        let! fortyTwo = one |> TaskSeq.head
+        fortyTwo |> should equal 42
+        x |> should equal 44
+        let! fortyTwo = one |> TaskSeq.head
+        fortyTwo |> should equal 42
+        x |> should equal 46
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryHead __special-case__ prove early side effect is executed`` () = task {
+        let mutable x = 42
+
+        let one = taskSeq {
+            x <- x + 1
+            x <- x + 1
+            yield 42
+            x <- x + 200  // we won't get here!
+        }
+
+        let! fortyTwo = one |> TaskSeq.tryHead
+        fortyTwo |> should equal (Some 42)
+        x |> should equal 44
+        let! fortyTwo = one |> TaskSeq.tryHead
+        fortyTwo |> should equal (Some 42)
+        x |> should equal 46
+
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-head gets the head item in a longer sequence, with mutation`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+
+        let! ten = TaskSeq.head ts
+        ten |> should equal 1
+
+        // side effect, reiterating causes it to execute again!
+        let! twenty = TaskSeq.head ts
+        twenty |> should not' (equal 1) // different test data changes first item counter differently
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-tryHead gets the head item in a longer sequence, with mutation`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+
+        let! ten = TaskSeq.tryHead ts
+        ten |> should equal (Some 1)
+
+        // side effect, reiterating causes it to execute again!
+        let! twenty = TaskSeq.tryHead ts
+        twenty |> should not' (equal (Some 1)) // different test data changes first item counter differently
+    }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
@@ -7,6 +7,10 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+//
+// TaskSeq.head
+// TaskSeq.tryHead
+//
 
 module EmptySeq =
 
@@ -109,7 +113,7 @@ module SideEffects =
         let! fortytwo = one |> TaskSeq.tryHead
         fortytwo |> should equal (Some 42)
 
-         // the statement after 'yield' will never be reached, the mutable will not be updated
+        // the statement after 'yield' will never be reached, the mutable will not be updated
         let! stillFortyTwo = one |> TaskSeq.tryHead
         stillFortyTwo |> should equal (Some 42)
 
@@ -123,7 +127,7 @@ module SideEffects =
             x <- x + 1
             x <- x + 1
             yield 42
-            x <- x + 200  // we won't get here!
+            x <- x + 200 // we won't get here!
         }
 
         let! fortyTwo = one |> TaskSeq.head
@@ -142,7 +146,7 @@ module SideEffects =
             x <- x + 1
             x <- x + 1
             yield 42
-            x <- x + 200  // we won't get here!
+            x <- x + 200 // we won't get here!
         }
 
         let! fortyTwo = one |> TaskSeq.tryHead

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.IsEmpty.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.IsEmpty.fs
@@ -1,0 +1,67 @@
+module FSharpy.Tests.IsEmpty
+
+open System.Threading.Tasks
+open Xunit
+open FsUnit.Xunit
+open FsToolkit.ErrorHandling
+
+open FSharpy
+
+module EmptySeq =
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-isEmpty returns true for empty`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.isEmpty
+        |> Task.map (should be True)
+
+module Immutable =
+    [<Fact>]
+    let ``TaskSeq-isEmpty returns false for singleton`` () =
+        taskSeq { yield 42 }
+        |> TaskSeq.isEmpty
+        |> Task.map (should be False)
+
+    [<Fact>]
+    let ``TaskSeq-isEmpty returns false for delayed singleton sequence`` () =
+        Gen.sideEffectTaskSeqMs 200<ms> 400<ms> 3
+        |> TaskSeq.isEmpty
+        |> Task.map (should be False)
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-isEmpty returns false for non-empty`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.isEmpty
+        |> Task.map (should be False)
+
+module SideEffects =
+    [<Fact>]
+    let ``TaskSeq-isEmpty prove that it won't execute side effects after the first item`` () =
+        let mutable i = 0
+
+        taskSeq {
+            i <- i + 1
+            yield 42
+            i <- i + 1
+        }
+        |> TaskSeq.isEmpty
+        |> Task.map (should be False)
+        |> Task.map (fun () -> i |> should equal 1)
+
+    [<Fact>]
+    let ``TaskSeq-isEmpty prove that it does execute side effects if empty`` () =
+        let mutable i = 0
+
+        taskSeq {
+            i <- i + 1
+            i <- i + 1
+        }
+        |> TaskSeq.isEmpty
+        |> Task.map (should be True)
+        |> Task.map (fun () -> i |> should equal 2)
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-isEmpty returns false for non-empty`` variant =
+        Gen.getSeqWithSideEffect variant
+        |> TaskSeq.isEmpty
+        |> Task.map (should be False)

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
@@ -8,240 +8,300 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 
-[<Fact>]
-let ``TaskSeq-item throws on empty sequences`` () = task {
-    fun () -> TaskSeq.empty<string> |> TaskSeq.item 0 |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+module EmptySeq =
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-item throws on empty sequences`` variant = task {
+        fun () -> Gen.getEmptyVariant variant |> TaskSeq.item 0 |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
 
-[<Fact>]
-let ``TaskSeq-item throws on empty sequence - variant`` () = task {
-    fun () -> taskSeq { do () } |> TaskSeq.item 50000 |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-item throws on empty sequence - high index`` variant = task {
+        fun () ->
+            Gen.getEmptyVariant variant
+            |> TaskSeq.item 50000
+            |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
 
-[<Fact>]
-let ``TaskSeq-item throws when not found`` () = task {
-    fun () ->
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.item 51
-        |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-tryItem returns None on empty sequences`` variant = task {
+        let! nothing = Gen.getEmptyVariant variant |> TaskSeq.tryItem 0
+        nothing |> should be None'
+    }
 
-[<Fact>]
-let ``TaskSeq-item throws when not found - variant`` () = task {
-    fun () ->
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.item Int32.MaxValue
-        |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-tryItem returns None on empty sequence - high index`` variant = task {
+        let! nothing = Gen.getEmptyVariant variant |> TaskSeq.tryItem 50000
+        nothing |> should be None'
+    }
 
-[<Fact>]
-let ``TaskSeq-item throws when accessing 2nd item in singleton sequence`` () = task {
-    fun () -> taskSeq { yield 10 } |> TaskSeq.item 1 |> Task.ignore // zero-based!
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+module Singleton =
+    [<Fact>]
+    let ``TaskSeq-item gets the first item in a singleton sequence`` () = task {
+        let! head = taskSeq { yield 10 } |> TaskSeq.item 0 // zero-based!
+        head |> should equal 10
+    }
 
-[<Fact>]
-let ``TaskSeq-item always throws with negative values`` () = task {
-    let make50 () = Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
+    [<Fact>]
+    let ``TaskSeq-tryItem gets the first item in a singleton sequence`` () = task {
+        let! head = taskSeq { yield 10 } |> TaskSeq.tryItem 0 // zero-based!
+        head |> should be Some'
+        head |> should equal (Some 10)
+    }
 
-    fun () -> make50 () |> TaskSeq.item -1 |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
+    [<Fact>]
+    let ``TaskSeq-item throws when accessing 2nd item in singleton sequence`` () = task {
+        fun () -> taskSeq { yield 10 } |> TaskSeq.item 1 |> Task.ignore // zero-based!
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
 
-    fun () -> make50 () |> TaskSeq.item -10000 |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
+    [<Fact>]
+    let ``TaskSeq-tryItem returns None when accessing 2nd item in singleton sequence`` () = task {
+        let! nothing = taskSeq { yield 10 } |> TaskSeq.tryItem 1 // zero-based!
+        nothing |> should be None'
+    }
 
-    fun () -> make50 () |> TaskSeq.item Int32.MinValue |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-item throws when not found`` variant = task {
+        fun () ->
+            Gen.getSeqImmutable variant
+            |> TaskSeq.item 10
+            |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
 
-    fun () -> TaskSeq.empty<string> |> TaskSeq.item -1 |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryItem returns None when not found`` variant = task {
+        let! nothing = Gen.getSeqImmutable variant |> TaskSeq.tryItem 10 // zero-based index
 
-    fun () -> TaskSeq.empty<string> |> TaskSeq.item -10000 |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
+        nothing |> should be None'
+    }
 
-    fun () ->
-        TaskSeq.empty<string>
-        |> TaskSeq.item Int32.MinValue
-        |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-item can get the first and last item in a longer sequence`` variant = task {
+        let! head = Gen.getSeqImmutable variant |> TaskSeq.item 0
+        let! tail = Gen.getSeqImmutable variant |> TaskSeq.item 9
+        head |> should equal 1
+        tail |> should equal 10
+    }
 
-[<Fact>]
-let ``TaskSeq-tryItem returns None on empty sequences`` () = task {
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem 0
-    nothing |> should be None'
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryItem can get the first and last item in a longer sequence`` variant = task {
+        let! head = Gen.getSeqImmutable variant |> TaskSeq.tryItem 0 // zero-based!
+        let! tail = Gen.getSeqImmutable variant |> TaskSeq.tryItem 9
 
-[<Fact>]
-let ``TaskSeq-tryItem returns None on empty sequence - variant`` () = task {
-    let! nothing = taskSeq { do () } |> TaskSeq.tryItem 50000
-    nothing |> should be None'
-}
+        head |> should equal (Some 1)
+        tail |> should equal (Some 10)
+    }
 
-[<Fact>]
-let ``TaskSeq-tryItem returns None when not found`` () = task {
-    let! nothing =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryItem 50 // zero-based index, so a sequence of 50 items has its last item at index 49
+module SideEffect =
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-item prove it searches the whole sequence`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
 
-    nothing |> should be None'
-}
+        fun () -> ts |> TaskSeq.item 10 |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
 
-[<Fact>]
-let ``TaskSeq-tryItem returns None when not found - variant`` () = task {
-    let! nothing =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryItem Int32.MaxValue
+        let! head = TaskSeq.head ts
+        head |> should equal 11 // all side effects have executed
+    }
 
-    nothing |> should be None'
-}
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-tryItem prove it searches the whole sequence`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+        let! item = ts |> TaskSeq.tryItem 10
 
-[<Fact>]
-let ``TaskSeq-tryItem returns None when accessing 2nd item in singleton sequence`` () = task {
-    let! nothing = taskSeq { yield 10 } |> TaskSeq.tryItem 1 // zero-based!
-    nothing |> should be None'
-}
+        item |> should be None'
+        let! head = TaskSeq.head ts
+        head |> should equal 11 // all side effects have executed
+    }
 
-[<Fact>]
-let ``TaskSeq-tryItem returns None throws with negative values`` () = task {
-    let make50 () = Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
+    [<Fact>]
+    let ``TaskSeq-item prove we don't iterate further than the found item`` () = task {
+        let mutable i = 0
 
-    let! nothing = make50 () |> TaskSeq.tryItem -1
-    nothing |> should be None'
-
-    let! nothing = make50 () |> TaskSeq.tryItem -10000
-    nothing |> should be None'
-
-    let! nothing = make50 () |> TaskSeq.tryItem Int32.MinValue
-    nothing |> should be None'
-
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem -1
-    nothing |> should be None'
-
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem -10000
-    nothing |> should be None'
-
-    let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem Int32.MinValue
-    nothing |> should be None'
-}
-
-[<Fact>]
-let ``TaskSeq-item can get the first item in a longer sequence`` () = task {
-    let! head =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.item 0
-
-    head |> should equal 1
-}
-
-[<Fact>]
-let ``TaskSeq-item can get the last item in a longer sequence`` () = task {
-    let! head =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.item 49
-
-    head |> should equal 50
-}
-
-[<Fact>]
-let ``TaskSeq-item can get the first item in a singleton sequence`` () = task {
-    let! head = taskSeq { yield 10 } |> TaskSeq.item 0 // zero-based index!
-    head |> should equal 10
-}
-
-[<Fact>]
-let ``TaskSeq-tryItem can get the first item in a longer sequence`` () = task {
-    let! head =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryItem 0 // zero-based!
-
-    head |> should be Some'
-    head |> should equal (Some 1)
-}
-
-[<Fact>]
-let ``TaskSeq-tryItem in a very long sequence (5_000 items - slow variant)`` () = task {
-    let! head =
-        Gen.sideEffectTaskSeq_Sequential 5_001
-        |> TaskSeq.tryItem 5_000 // zero-based!
-
-    head |> should be Some'
-    head |> should equal (Some 5_001)
-}
-
-[<Fact>]
-let ``TaskSeq-tryItem in a very long sequence (50_000 items - slow variant)`` () = task {
-    let! head =
-        Gen.sideEffectTaskSeq_Sequential 50_001
-        |> TaskSeq.tryItem 50_000 // zero-based!
-
-    head |> should be Some'
-    head |> should equal (Some 50_001)
-}
-
-[<Fact>]
-let ``TaskSeq-tryItem in a very long sequence (50_000 items - fast variant)`` () = task {
-    let! head =
-        // using taskSeq instead of the delayed-task approach above, which creates an extra closure for each
-        // task, we can really see the speed of the 'taskSeq' CE!! This is
-        taskSeq {
-            for i in [ 0..50_000 ] do
-                yield i
+        let ts = taskSeq {
+            i <- i + 1
+            yield 1
+            i <- i + 1
+            yield 2
+            i <- i + 1 // we never get here
         }
-        |> TaskSeq.tryItem 50_000 // zero-based!
 
-    head |> should be Some'
-    head |> should equal (Some 50_000)
-}
+        // zero-based index
+        do! ts |> TaskSeq.item 1 |> Task.map (should equal 2)
+        i |> should equal 2 // last side effect is not executed
+    }
 
-[<Fact>]
-let ``TaskSeq-tryItem in a very long sequence (50_000 items - using sync Seq)`` () = task {
-    // this test is just for smoke-test perf comparison with TaskSeq above
-    let head =
-        seq {
-            for i in [ 0..50_000 ] do
-                yield i
+    [<Fact>]
+    let ``TaskSeq-tryItem prove we don't iterate further than the found item`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            yield 1
+            i <- i + 1
+            yield 2
+            i <- i + 1 // we never get here
         }
-        |> Seq.tryItem 50_000 // zero-based!
 
-    head |> should be Some'
-    head |> should equal (Some 50_000)
-}
+        // zero-based index
+        do! ts |> TaskSeq.tryItem 1 |> Task.map (should equal (Some 2))
+        i |> should equal 2 // last side effect is not executed
+    }
 
-[<Fact>]
-let ``TaskSeq-tryItem in a very long sequence (500_000 items - fast variant)`` () = task {
-    let! head =
-        taskSeq {
-            for i in [ 0..500_000 ] do
-                yield i
+    [<Fact>]
+    let ``TaskSeq-item prove we iterate beyond the end when not found`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            yield 1
+            i <- i + 1
+            yield 2
+            i <- i + 1 // we never get here
         }
-        |> TaskSeq.tryItem 500_000 // zero-based!
 
-    head |> should be Some'
-    head |> should equal (Some 500_000)
-}
+        // zero-based
+        fun () -> ts |> TaskSeq.item 2 |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
 
-[<Fact>]
-let ``TaskSeq-tryItem in a very long sequence (500_000 items - using sync Seq)`` () = task {
-    // this test is just for smoke-test perf comparison with TaskSeq above
-    let head =
-        seq {
-            for i in [ 0..500_000 ] do
-                yield i
+        i |> should equal 3 // last side effect MUST be executed
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryItem prove we iterate beyond the end when not found`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            yield 1
+            i <- i + 1
+            yield 2
+            i <- i + 1 // we never get here
         }
-        |> Seq.tryItem 500_000 // zero-based!
 
-    head |> should be Some'
-    head |> should equal (Some 500_000)
-}
+        do! ts |> TaskSeq.tryItem 2 |> Task.map (should be None')
+        i |> should equal 3 // last side effect MUST be executed
+    }
 
-[<Fact>]
-let ``TaskSeq-tryItem gets the first item in a singleton sequence`` () = task {
-    let! head = taskSeq { yield 10 } |> TaskSeq.tryItem 0 // zero-based!
-    head |> should be Some'
-    head |> should equal (Some 10)
-}
+
+module Performance =
+
+    [<Theory; InlineData 10_000; InlineData 100_000; InlineData 1_000_000>]
+    let ``TaskSeq-tryItem in a very long sequence -- yield variant`` total = task {
+        let! head =
+            taskSeq {
+                for i in [ 0..total ] do
+                    yield i
+            }
+            |> TaskSeq.tryItem total // zero-based!
+
+        head |> should equal (Some total)
+    }
+
+    [<Theory; InlineData 10_000; InlineData 100_000; InlineData 1_000_000>]
+    let ``[compare] Seq-tryItem in a very long sequence -- yield using F# Seq`` total = task {
+        // this test is just for smoke-test perf comparison with TaskSeq above
+        let head =
+            seq {
+                for i in [ 0..total ] do
+                    yield i
+            }
+            |> Seq.tryItem total // zero-based!
+
+        head |> should equal (Some total)
+    }
+
+    [<Theory; InlineData 10_000; InlineData 100_000; InlineData 1_000_000>]
+    let ``TaskSeq-tryItem in a very long sequence -- array variant`` total = task {
+        let! head = taskSeq { yield! [| 0..total |] } |> TaskSeq.tryItem total // zero-based!
+
+        head |> should equal (Some total)
+    }
+
+    [<Theory; InlineData 10_000; InlineData 100_000; InlineData 1_000_000>]
+    let ``[compare] Seq-tryItem in a very long sequence -- array using F# Seq`` total = task {
+        // this test is just for smoke-test perf comparison with TaskSeq above
+        let head = seq { yield! [| 0..total |] } |> Seq.tryItem total // zero-based!
+
+        head |> should equal (Some total)
+    }
+
+module Other =
+    [<Fact>]
+    let ``TaskSeq-item accepts Int-MaxValue`` () = task {
+        let make50 () = Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
+
+        fun () -> make50 () |> TaskSeq.item Int32.MaxValue |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+
+        fun () ->
+            TaskSeq.empty<string>
+            |> TaskSeq.item Int32.MaxValue
+            |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryItem accepts Int-MaxValue`` () = task {
+        let! nope =
+            Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
+            |> TaskSeq.tryItem Int32.MaxValue
+
+        nope |> should be None'
+
+        let! nope = TaskSeq.empty<string> |> TaskSeq.tryItem Int32.MaxValue
+        nope |> should be None'
+    }
+
+    [<Fact>]
+    let ``TaskSeq-item always throws with negative values`` () = task {
+        let make50 () = Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
+
+        fun () -> make50 () |> TaskSeq.item -1 |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+
+        fun () -> make50 () |> TaskSeq.item -10000 |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+
+        fun () -> make50 () |> TaskSeq.item Int32.MinValue |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+
+        fun () -> TaskSeq.empty<string> |> TaskSeq.item -1 |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+
+        fun () -> TaskSeq.empty<string> |> TaskSeq.item -10000 |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+
+        fun () ->
+            TaskSeq.empty<string>
+            |> TaskSeq.item Int32.MinValue
+            |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryItem throws with negative values`` () = task {
+        let make50 () = Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
+
+        let! nothing = make50 () |> TaskSeq.tryItem -1
+        nothing |> should be None'
+
+        let! nothing = make50 () |> TaskSeq.tryItem -10000
+        nothing |> should be None'
+
+        let! nothing = make50 () |> TaskSeq.tryItem Int32.MinValue
+        nothing |> should be None'
+
+        let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem -1
+        nothing |> should be None'
+
+        let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem -10000
+        nothing |> should be None'
+
+        let! nothing = TaskSeq.empty<string> |> TaskSeq.tryItem Int32.MinValue
+        nothing |> should be None'
+    }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
@@ -7,6 +7,10 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+//
+// TaskSeq.item
+// TaskSeq.tryItem
+//
 
 module EmptySeq =
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -76,41 +76,178 @@ module Immutable =
     }
 
 module SideEffects =
-    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
-    let ``TaskSeq-iteri should go over all items`` variant = task {
-        let tq = Gen.getSeqWithSideEffect variant
-        let mutable sum = 0
-        do! tq |> TaskSeq.iteri (fun i _ -> sum <- sum + i)
-        sum |> should equal 45 // index starts at 0
+    [<Fact>]
+    let ``TaskSeq-iter prove we execute empty-seq side-effects`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            i <- i + 1 // we should get here
+        }
+
+        do! ts |> TaskSeq.iter (fun _ -> ())
+        do! ts |> TaskSeq.iter (fun _ -> ())
+        do! ts |> TaskSeq.iter (fun _ -> ())
+        i |> should equal 9
+    }
+
+    [<Fact>]
+    let ``TaskSeq-iteri prove we execute empty-seq side-effects`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            i <- i + 1 // we should get here
+        }
+
+        do! ts |> TaskSeq.iteri (fun _ _ -> ())
+        do! ts |> TaskSeq.iteri (fun _ _ -> ())
+        do! ts |> TaskSeq.iteri (fun _ _ -> ())
+        i |> should equal 9
+    }
+
+    [<Fact>]
+    let ``TaskSeq-iterAsync prove we execute empty-seq side-effects`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            i <- i + 1 // we should get here
+        }
+
+        do! ts |> TaskSeq.iterAsync (fun _ -> task { return () })
+        do! ts |> TaskSeq.iterAsync (fun _ -> task { return () })
+        do! ts |> TaskSeq.iterAsync (fun _ -> task { return () })
+        i |> should equal 9
+    }
+
+    [<Fact>]
+    let ``TaskSeq-iteriAsync prove we execute empty-seq side-effects`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            i <- i + 1 // we should get here
+        }
+
+        do! ts |> TaskSeq.iteriAsync (fun _ _ -> task { return () })
+        do! ts |> TaskSeq.iteriAsync (fun _ _ -> task { return () })
+        do! ts |> TaskSeq.iteriAsync (fun _ _ -> task { return () })
+        i |> should equal 9
+    }
+
+    [<Fact>]
+    let ``TaskSeq-iter prove we execute after-effects`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            yield 42
+            i <- i + 1 // we should get here
+        }
+
+        do! ts |> TaskSeq.iter (fun _ -> ())
+        do! ts |> TaskSeq.iter (fun _ -> ())
+        do! ts |> TaskSeq.iter (fun _ -> ())
+        i |> should equal 9
+    }
+
+    [<Fact>]
+    let ``TaskSeq-iteri prove we execute after-effects`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            yield 42
+            i <- i + 1 // we should get here
+        }
+
+        do! ts |> TaskSeq.iteri (fun _ _ -> ())
+        do! ts |> TaskSeq.iteri (fun _ _ -> ())
+        do! ts |> TaskSeq.iteri (fun _ _ -> ())
+        i |> should equal 9
+    }
+
+    [<Fact>]
+    let ``TaskSeq-iterAsync prove we execute after-effects`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            yield 42
+            i <- i + 1 // we should get here
+        }
+
+        do! ts |> TaskSeq.iterAsync (fun _ -> task { return () })
+        do! ts |> TaskSeq.iterAsync (fun _ -> task { return () })
+        do! ts |> TaskSeq.iterAsync (fun _ -> task { return () })
+        i |> should equal 9
+    }
+
+    [<Fact>]
+    let ``TaskSeq-iteriAsync prove we execute after-effects`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            yield 42
+            i <- i + 1 // we should get here
+        }
+
+        do! ts |> TaskSeq.iteriAsync (fun _ _ -> task { return () })
+        do! ts |> TaskSeq.iteriAsync (fun _ _ -> task { return () })
+        do! ts |> TaskSeq.iteriAsync (fun _ _ -> task { return () })
+        i |> should equal 9
     }
 
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-iter should go over all items`` variant = task {
-        let tq = Gen.getSeqWithSideEffect variant
-        let mutable sum = 0
-        do! tq |> TaskSeq.iter (fun item -> sum <- sum + item)
-        sum |> should equal 55 // task-dummies started at 1
+        let ts = Gen.getSeqWithSideEffect variant
+        do! ts |> TaskSeq.iter (fun _ -> ())
+        do! ts |> TaskSeq.iter (fun _ -> ())
+        do! ts |> TaskSeq.iter (fun _ -> ())
+        // incl. the iteration of 'last', we reach 40
+        do! ts |> TaskSeq.last |> Task.map (should equal 40)
     }
 
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-iteri show that side effects are executed multiple times`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+        do! ts |> TaskSeq.iteri (fun _ _ -> ())
+        do! ts |> TaskSeq.iteri (fun _ _ -> ())
+        do! ts |> TaskSeq.iteri (fun _ _ -> ())
+        // incl. the iteration of 'last', we reach 40
+        do! ts |> TaskSeq.last |> Task.map (should equal 40)
+    }
 
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-iter multiple iterations over same sequence`` variant = task {
-        let tq = Gen.getSeqWithSideEffect variant
+        let ts = Gen.getSeqWithSideEffect variant
         let mutable sum = 0
-        do! tq |> TaskSeq.iter (fun item -> printfn "A:%i" item; sum <- sum + item)
-        do! tq |> TaskSeq.iter (fun item -> printfn "B:%i" item; sum <- sum + item)
-        do! tq |> TaskSeq.iter (fun item -> printfn "C:%i" item; sum <- sum + item)
-        do! tq |> TaskSeq.iter (fun item -> printfn "D:%i" item; sum <- sum + item)
+
+        do! TaskSeq.iter (fun item -> sum <- sum + item) ts
+        do! TaskSeq.iter (fun item -> sum <- sum + item) ts
+        do! TaskSeq.iter (fun item -> sum <- sum + item) ts
+        do! TaskSeq.iter (fun item -> sum <- sum + item) ts
+
         sum |> should equal 820 // side-effected tasks, so 'item' DOES CHANGE, each next iteration starts 10 higher
     }
 
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-iteriAsync should go over all items`` variant = task {
-        let tq = Gen.getSeqWithSideEffect variant
+        let ts = Gen.getSeqWithSideEffect variant
         let mutable sum = 0
 
         do!
-            tq
+            ts
             |> TaskSeq.iteriAsync (fun i _ -> task { sum <- sum + i })
 
         sum |> should equal 45 // index starts at 0
@@ -118,12 +255,8 @@ module SideEffects =
 
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-iterAsync should go over all items`` variant = task {
-        let tq = Gen.getSeqWithSideEffect variant
+        let ts = Gen.getSeqWithSideEffect variant
         let mutable sum = 0
-
-        do!
-            tq
-            |> TaskSeq.iterAsync (fun item -> task { sum <- sum + item })
-
+        do! TaskSeq.iterAsync (fun item -> task { sum <- sum + item }) ts
         sum |> should equal 55 // task-dummies started at 1
     }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -5,6 +5,13 @@ open FsUnit.Xunit
 
 open FSharpy
 
+//
+// TaskSeq.iter
+// TaskSeq.iteri
+// TaskSeq.iterAsync
+// TaskSeq.iteriAsync
+//
+
 module EmptySeq =
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-iteri does nothing on empty sequences`` variant = task {

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
@@ -7,6 +7,11 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+//
+// TaskSeq.last
+// TaskSeq.tryLast
+//
+
 module EmptySeq =
 
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
@@ -7,6 +7,12 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+//
+// TaskSeq.length
+// TaskSeq.lengthBy
+// TaskSeq.lengthByAsync
+//
+
 module EmptySeq =
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-length returns zero on empty sequences`` variant = task {

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
@@ -77,6 +77,62 @@ module Immutable =
 
 module SideSeffects =
     [<Fact>]
+    let ``TaskSeq-length prove we execute after-effects`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            yield 42
+            i <- i + 1 // we should get here
+        }
+
+        do! ts |> TaskSeq.length |> Task.ignore
+        do! ts |> TaskSeq.length |> Task.ignore
+        do! ts |> TaskSeq.length |> Task.ignore
+        i |> should equal 9
+    }
+
+    [<Fact>]
+    let ``TaskSeq-lengthBy prove we execute after-effects`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            yield 42
+            i <- i + 1 // we should get here
+        }
+
+        do! ts |> TaskSeq.lengthBy (fun _ -> true) |> Task.ignore
+        do! ts |> TaskSeq.lengthBy (fun _ -> true) |> Task.ignore
+        do! ts |> TaskSeq.lengthBy (fun _ -> true) |> Task.ignore
+        i |> should equal 9
+    }
+
+    [<Fact>]
+    let ``TaskSeq-lengthByAsync prove we execute after-effects`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            yield 42
+            i <- i + 1 // we should get here
+        }
+
+        let lenBy =
+            TaskSeq.lengthByAsync (fun _ -> task { return true })
+            >> Task.ignore
+
+        do! lenBy ts
+        do! lenBy ts
+        do! lenBy ts
+
+        i |> should equal 9
+    }
+
+    [<Fact>]
     let ``TaskSeq-length with sequence that changes length`` () = task {
         let mutable i = 0
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -6,6 +6,13 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+//
+// TaskSeq.map
+// TaskSeq.mapi
+// TaskSeq.mapAsync
+// TaskSeq.mapiAsync
+//
+
 /// Asserts that a sequence contains the char values 'A'..'J'.
 let validateSequence ts =
     ts

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -7,144 +7,218 @@ open FsToolkit.ErrorHandling
 open FSharpy
 
 /// Asserts that a sequence contains the char values 'A'..'J'.
-let validateSequence sequence =
-    sequence
-    |> Seq.map string
-    |> String.concat ""
-    |> should equal "ABCDEFGHIJ"
+let validateSequence ts =
+    ts
+    |> TaskSeq.toSeqCachedAsync
+    |> Task.map (Seq.map string)
+    |> Task.map (String.concat "")
+    |> Task.map (should equal "ABCDEFGHIJ")
 
 /// Validates for "ABCDEFGHIJ" char sequence, or any amount of char-value higher
-let validateSequenceWithOffset offset sequence =
+let validateSequenceWithOffset offset ts =
     let expected =
         [ 'A' .. 'J' ]
         |> List.map (int >> (+) offset >> char >> string)
         |> String.concat ""
 
-    sequence
-    |> Seq.map string
-    |> String.concat ""
-    |> should equal expected
+    ts
+    |> TaskSeq.toSeqCachedAsync
+    |> Task.map (Seq.map string)
+    |> Task.map (String.concat "")
+    |> Task.map (should equal expected)
 
-[<Fact>]
-let ``TaskSeq-map maps in correct order`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
+module EmptySeq =
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-map maps in correct order`` variant =
+        Gen.getEmptyVariant variant
         |> TaskSeq.map (fun item -> char (item + 64))
-        |> TaskSeq.toSeqCachedAsync
+        |> verifyEmpty
 
-    validateSequence sq
-}
-
-[<Fact>]
-let ``TaskSeq-mapi maps in correct order`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-mapi maps in correct order`` variant =
+        Gen.getEmptyVariant variant
         |> TaskSeq.mapi (fun i _ -> char (i + 65))
-        |> TaskSeq.toSeqCachedAsync
+        |> verifyEmpty
 
-    validateSequence sq
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-mapAsync maps in correct order`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
+        |> verifyEmpty
 
-[<Fact>]
-let ``TaskSeq-map can access mutables which are mutated in correct order`` () = task {
-    let mutable sum = 0
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-mapiAsync maps in correct order`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.mapiAsync (fun i _ -> task { return char (i + 65) })
+        |> verifyEmpty
 
-    let! sq =
-        Gen.sideEffectTaskSeq 10
+
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-map maps in correct order`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.map (fun item -> char (item + 64))
+        |> validateSequence
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-mapi maps in correct order`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.mapi (fun i _ -> char (i + 65))
+        |> validateSequence
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-mapAsync maps in correct order`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
+        |> validateSequence
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-mapiAsync maps in correct order`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.mapiAsync (fun i _ -> task { return char (i + 65) })
+        |> validateSequence
+
+module SideEffects =
+    [<Fact>]
+    let ``TaskSeq-map prove that it has no effect until executed`` () =
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1 // we should not get here
+            i <- i + 1
+            yield 42
+            i <- i + 1
+        }
+
+        // point of this test: just calling 'map' won't execute anything of the sequence!
+        let _ =
+            ts
+            |> TaskSeq.map (fun x -> x + 10)
+            |> TaskSeq.map (fun x -> x + 10)
+            |> TaskSeq.map (fun x -> x + 10)
+
+        // multiple maps have no effect unless executed
+        i |> should equal 0
+
+    [<Fact>]
+    let ``TaskSeq-mapi prove that it has no effect until executed`` () =
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1 // we should not get here
+            i <- i + 1
+            yield 42
+            i <- i + 1
+        }
+
+        // point of this test: just calling 'map' won't execute anything of the sequence!
+        let _ =
+            ts
+            |> TaskSeq.mapi (fun x _ -> x + 10)
+            |> TaskSeq.mapi (fun x _ -> x + 10)
+            |> TaskSeq.mapi (fun x _ -> x + 10)
+
+        // multiple maps have no effect unless executed
+        i |> should equal 0
+
+    [<Fact>]
+    let ``TaskSeq-mapAsync prove that it has no effect until executed`` () =
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1 // we should not get here
+            i <- i + 1
+            yield 42
+            i <- i + 1
+        }
+
+        // point of this test: just calling 'map' won't execute anything of the sequence!
+        let _ =
+            ts
+            |> TaskSeq.mapAsync (fun x -> task { return x + 10 })
+            |> TaskSeq.mapAsync (fun x -> task { return x + 10 })
+            |> TaskSeq.mapAsync (fun x -> task { return x + 10 })
+
+        // multiple maps have no effect unless executed
+        i |> should equal 0
+
+    [<Fact>]
+    let ``TaskSeq-mapiAsync prove that it has no effect until executed`` () =
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1 // we should not get here
+            i <- i + 1
+            yield 42
+            i <- i + 1
+        }
+
+        // point of this test: just calling 'map' won't execute anything of the sequence!
+        let _ =
+            ts
+            |> TaskSeq.mapiAsync (fun x _ -> task { return x + 10 })
+            |> TaskSeq.mapiAsync (fun x _ -> task { return x + 10 })
+            |> TaskSeq.mapiAsync (fun x _ -> task { return x + 10 })
+
+        // multiple maps have no effect unless executed
+        i |> should equal 0
+
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-map can access mutables which are mutated in correct order`` variant =
+        let mutable sum = 0
+
+        Gen.getSeqWithSideEffect variant
         |> TaskSeq.map (fun item ->
             sum <- sum + 1
             char (sum + 64))
-        |> TaskSeq.toSeqCachedAsync
+        |> validateSequence
+        |> Task.map (fun () -> sum |> should equal 10)
 
-    sum |> should equal 10
-    validateSequence sq
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-mapi can access mutables which are mutated in correct order`` variant =
+        let mutable sum = 0
 
-[<Fact>]
-let ``TaskSeq-mapi can access mutables which are mutated in correct order`` () = task {
-    let mutable sum = 0
-
-    let! sq =
-        Gen.sideEffectTaskSeq 10
+        Gen.getSeqWithSideEffect variant
         |> TaskSeq.mapi (fun i _ ->
             sum <- i + 1
             char (sum + 64))
-        |> TaskSeq.toSeqCachedAsync
+        |> validateSequence
+        |> Task.map (fun () -> sum |> should equal 10)
 
-    sum |> should equal 10
-    validateSequence sq
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-mapAsync can map the same sequence multiple times`` variant = task {
+        let doMap = TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
+        let ts = Gen.getSeqWithSideEffect variant
 
-[<Fact>]
-let ``TaskSeq-mapAsync maps in correct order`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
-        |> TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
-        |> TaskSeq.toSeqCachedAsync
+        // each time we do GetAsyncEnumerator(), and go through the whole sequence,
+        // the whole sequence gets re-evaluated, causing our +1 side-effect to run again.
+        do! doMap ts |> validateSequence
+        do! doMap ts |> validateSequenceWithOffset 10 // the mutable is 10 higher
+        do! doMap ts |> validateSequenceWithOffset 20 // again
+        do! doMap ts |> validateSequenceWithOffset 30 // again
+    }
 
-    validateSequence sq
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-mapAsync can access mutables which are mutated in correct order`` variant =
+        let mutable sum = 0
 
-[<Fact>]
-let ``TaskSeq-mapAsync can map the same sequence multiple times`` () = task {
-    let mapAndCache =
-        TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
-        >> TaskSeq.toSeqCachedAsync
-
-    let ts = Gen.sideEffectTaskSeq_Sequential 10
-
-    let! result1 = mapAndCache ts
-    let! result2 = mapAndCache ts
-    let! result3 = mapAndCache ts
-    let! result4 = mapAndCache ts
-    validateSequence result1
-
-    // each time we do GetAsyncEnumerator(), and go through the whole sequence,
-    // the whole sequence gets re-evaluated, causing our +1 side-effect to run again.
-    validateSequenceWithOffset 10 result2 // the mutable is 10 higher
-    validateSequenceWithOffset 20 result3 // again
-    validateSequenceWithOffset 30 result4 // again
-}
-
-[<Fact>]
-let ``TaskSeq-mapiAsync maps in correct order`` () = task {
-    let! sq =
-        Gen.sideEffectTaskSeq 10
-        |> TaskSeq.mapiAsync (fun i _ -> task { return char (i + 65) })
-        |> TaskSeq.toSeqCachedAsync
-
-    validateSequence sq
-}
-
-
-[<Fact>]
-let ``TaskSeq-mapAsync can access mutables which are mutated in correct order`` () = task {
-    let mutable sum = 0
-
-    let! sq =
-        Gen.sideEffectTaskSeq 10
+        Gen.getSeqWithSideEffect variant
         |> TaskSeq.mapAsync (fun item -> task {
             sum <- sum + 1
             return char (sum + 64)
         })
-        |> TaskSeq.toSeqCachedAsync
+        |> validateSequence
+        |> Task.map (fun () -> sum |> should equal 10)
 
-    sum |> should equal 10
-    validateSequence sq
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-mapiAsync can access mutables which are mutated in correct order`` variant =
+        let mutable data = '0'
 
-[<Fact>]
-let ``TaskSeq-mapiAsync can access mutables which are mutated in correct order`` () = task {
-    let mutable data = '0'
-
-    let! sq =
-        Gen.sideEffectTaskSeq 10
+        Gen.getSeqWithSideEffect variant
         |> TaskSeq.mapiAsync (fun i _ -> task {
             data <- char (i + 65)
             return data
         })
-        |> TaskSeq.toSeqCachedAsync
-
-    data |> should equal (char 74)
-    validateSequence sq
-}
+        |> validateSequence
+        |> Task.map (fun () -> data |> should equal (char 74))

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -175,7 +175,7 @@ module SideEffects =
         |> validateSequence
         |> Task.map (fun () -> sum |> should equal 10)
 
-    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-mapi can access mutables which are mutated in correct order`` variant =
         let mutable sum = 0
 
@@ -186,7 +186,7 @@ module SideEffects =
         |> validateSequence
         |> Task.map (fun () -> sum |> should equal 10)
 
-    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-mapAsync can map the same sequence multiple times`` variant = task {
         let doMap = TaskSeq.mapAsync (fun item -> task { return char (item + 64) })
         let ts = Gen.getSeqWithSideEffect variant
@@ -199,7 +199,7 @@ module SideEffects =
         do! doMap ts |> validateSequenceWithOffset 30 // again
     }
 
-    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-mapAsync can access mutables which are mutated in correct order`` variant =
         let mutable sum = 0
 
@@ -211,7 +211,7 @@ module SideEffects =
         |> validateSequence
         |> Task.map (fun () -> sum |> should equal 10)
 
-    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-mapiAsync can access mutables which are mutated in correct order`` variant =
         let mutable data = '0'
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
@@ -6,58 +6,108 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
-let validateSequence sq = task {
-    let! sq = TaskSeq.toArrayAsync sq
-    do sq |> Seq.toArray |> should equal [| 0..9 |]
-}
+let validateSequence sq =
+    TaskSeq.toArrayAsync sq
+    |> Task.map (Seq.toArray >> should equal [| 0..9 |])
 
-[<Fact>]
-let ``TaskSeq-ofAsyncArray should succeed`` () =
-    Array.init 10 (fun x -> async { return x })
-    |> TaskSeq.ofAsyncArray
-    |> validateSequence
+module EmptySeq =
+    [<Fact>]
+    let ``TaskSeq-ofAsyncArray with empty set`` () =
+        Array.init 0 (fun x -> async { return x })
+        |> TaskSeq.ofAsyncArray
+        |> verifyEmpty
 
-[<Fact>]
-let ``TaskSeq-ofAsyncList should succeed`` () =
-    List.init 10 (fun x -> async { return x })
-    |> TaskSeq.ofAsyncList
-    |> validateSequence
+    [<Fact>]
+    let ``TaskSeq-ofAsyncList with empty set`` () =
+        List.init 0 (fun x -> async { return x })
+        |> TaskSeq.ofAsyncList
+        |> verifyEmpty
 
-[<Fact>]
-let ``TaskSeq-ofAsyncSeq should succeed`` () =
-    Seq.init 10 (fun x -> async { return x })
-    |> TaskSeq.ofAsyncSeq
-    |> validateSequence
+    [<Fact>]
+    let ``TaskSeq-ofAsyncSeq with empty set`` () =
+        Seq.init 0 (fun x -> async { return x })
+        |> TaskSeq.ofAsyncSeq
+        |> verifyEmpty
 
-[<Fact>]
-let ``TaskSeq-ofTaskArray should succeed`` () =
-    Array.init 10 (fun x -> task { return x })
-    |> TaskSeq.ofTaskArray
-    |> validateSequence
+    [<Fact>]
+    let ``TaskSeq-ofTaskArray with empty set`` () =
+        Array.init 0 (fun x -> task { return x })
+        |> TaskSeq.ofTaskArray
+        |> verifyEmpty
 
-[<Fact>]
-let ``TaskSeq-ofTaskList should succeed`` () =
-    List.init 10 (fun x -> task { return x })
-    |> TaskSeq.ofTaskList
-    |> validateSequence
+    [<Fact>]
+    let ``TaskSeq-ofTaskList with empty set`` () =
+        List.init 0 (fun x -> task { return x })
+        |> TaskSeq.ofTaskList
+        |> verifyEmpty
 
-[<Fact>]
-let ``TaskSeq-ofTaskSeq should succeed`` () =
-    Seq.init 10 (fun x -> task { return x })
-    |> TaskSeq.ofTaskSeq
-    |> validateSequence
+    [<Fact>]
+    let ``TaskSeq-ofTaskSeq with empty set`` () =
+        Seq.init 0 (fun x -> task { return x })
+        |> TaskSeq.ofTaskSeq
+        |> verifyEmpty
 
-[<Fact>]
-let ``TaskSeq-ofResizeArray should succeed`` () =
-    ResizeArray [ 0..9 ]
-    |> TaskSeq.ofResizeArray
-    |> validateSequence
+    [<Fact>]
+    let ``TaskSeq-ofResizeArray with empty set`` () = ResizeArray() |> TaskSeq.ofResizeArray |> verifyEmpty
 
-[<Fact>]
-let ``TaskSeq-ofArray should succeed`` () = Array.init 10 id |> TaskSeq.ofArray |> validateSequence
+    [<Fact>]
+    let ``TaskSeq-ofArray with empty set`` () = Array.init 0 id |> TaskSeq.ofArray |> verifyEmpty
 
-[<Fact>]
-let ``TaskSeq-ofList should succeed`` () = List.init 10 id |> TaskSeq.ofList |> validateSequence
+    [<Fact>]
+    let ``TaskSeq-ofList with empty set`` () = List.init 0 id |> TaskSeq.ofList |> verifyEmpty
 
-[<Fact>]
-let ``TaskSeq-ofSeq should succeed`` () = Seq.init 10 id |> TaskSeq.ofSeq |> validateSequence
+    [<Fact>]
+    let ``TaskSeq-ofSeq with empty set`` () = Seq.init 0 id |> TaskSeq.ofSeq |> verifyEmpty
+
+
+module Immutable =
+    [<Fact>]
+    let ``TaskSeq-ofAsyncArray should succeed`` () =
+        Array.init 10 (fun x -> async { return x })
+        |> TaskSeq.ofAsyncArray
+        |> validateSequence
+
+    [<Fact>]
+    let ``TaskSeq-ofAsyncList should succeed`` () =
+        List.init 10 (fun x -> async { return x })
+        |> TaskSeq.ofAsyncList
+        |> validateSequence
+
+    [<Fact>]
+    let ``TaskSeq-ofAsyncSeq should succeed`` () =
+        Seq.init 10 (fun x -> async { return x })
+        |> TaskSeq.ofAsyncSeq
+        |> validateSequence
+
+    [<Fact>]
+    let ``TaskSeq-ofTaskArray should succeed`` () =
+        Array.init 10 (fun x -> task { return x })
+        |> TaskSeq.ofTaskArray
+        |> validateSequence
+
+    [<Fact>]
+    let ``TaskSeq-ofTaskList should succeed`` () =
+        List.init 10 (fun x -> task { return x })
+        |> TaskSeq.ofTaskList
+        |> validateSequence
+
+    [<Fact>]
+    let ``TaskSeq-ofTaskSeq should succeed`` () =
+        Seq.init 10 (fun x -> task { return x })
+        |> TaskSeq.ofTaskSeq
+        |> validateSequence
+
+    [<Fact>]
+    let ``TaskSeq-ofResizeArray should succeed`` () =
+        ResizeArray [ 0..9 ]
+        |> TaskSeq.ofResizeArray
+        |> validateSequence
+
+    [<Fact>]
+    let ``TaskSeq-ofArray should succeed`` () = Array.init 10 id |> TaskSeq.ofArray |> validateSequence
+
+    [<Fact>]
+    let ``TaskSeq-ofList should succeed`` () = List.init 10 id |> TaskSeq.ofList |> validateSequence
+
+    [<Fact>]
+    let ``TaskSeq-ofSeq should succeed`` () = Seq.init 10 id |> TaskSeq.ofSeq |> validateSequence

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Pick.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Pick.Tests.fs
@@ -275,7 +275,7 @@ module SideEffects =
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-pickAsync KeyNotFoundException only sometimes for mutated state`` variant = task {
         let ts = Gen.getSeqWithSideEffect variant
-        
+
         // first: error, item is not there
         fun () -> TaskSeq.pickAsync (pickerAsync 11) ts |> Task.ignore
         |> should throwAsyncExact typeof<KeyNotFoundException>
@@ -354,7 +354,7 @@ module SideEffects =
             i <- i + 1
         }
 
-        let! found = ts |> TaskSeq.pickAsync (pickerAsync 42 )
+        let! found = ts |> TaskSeq.pickAsync (pickerAsync 42)
         found |> should equal 42
         i |> should equal 0 // because no MoveNext after found item, the last statements are not executed
     }
@@ -389,12 +389,12 @@ module SideEffects =
                 i <- i + 1
         }
 
-        let! found = ts |> TaskSeq.pickAsync (pickerAsync 0 )
+        let! found = ts |> TaskSeq.pickAsync (pickerAsync 0)
         found |> should equal 0
         i |> should equal 0 // notice that it should be one higher if the statement after 'yield' is evaluated
 
         // pick some next item. We do get a new iterator, but mutable state is now starting at '1'
-        let! found = ts |> TaskSeq.pickAsync (pickerAsync 4 )
+        let! found = ts |> TaskSeq.pickAsync (pickerAsync 4)
         found |> should equal 4
         i |> should equal 4 // only partial evaluation!
     }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Pick.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Pick.Tests.fs
@@ -12,247 +12,543 @@ open FSharpy
 //
 // TaskSeq.pick
 // TaskSeq.pickAsync
-// the tryXXX versions are at the bottom half
-//
-
-[<Fact>]
-let ``TaskSeq-pick on an empty sequence raises KeyNotFoundException`` () = task {
-    fun () ->
-        TaskSeq.empty
-        |> TaskSeq.pick (fun x -> if x = 12 then Some x else None)
-        |> Task.ignore
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-[<Fact>]
-let ``TaskSeq-pick on an empty sequence raises KeyNotFoundException - variant`` () = task {
-    fun () ->
-        taskSeq { do () }
-        |> TaskSeq.pick (fun x -> if x = 12 then Some x else None)
-        |> Task.ignore
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-[<Fact>]
-let ``TaskSeq-pickAsync on an empty sequence raises KeyNotFoundException`` () = task {
-    fun () ->
-        TaskSeq.empty
-        |> TaskSeq.pickAsync (fun x -> task { return if x = 12 then Some x else None })
-        |> Task.ignore
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-[<Fact>]
-let ``TaskSeq-pick sad path raises KeyNotFoundException`` () = task {
-    fun () ->
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.pick (fun x -> if x = 0 then Some x else None) // dummy tasks sequence starts at 1
-        |> Task.ignore
-
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-[<Fact>]
-let ``TaskSeq-pickAsync sad path raises KeyNotFoundException`` () = task {
-    fun () ->
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.pickAsync (fun x -> task { return if x < 0 then Some x else None }) // dummy tasks sequence starts at 1
-        |> Task.ignore
-
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-[<Fact>]
-let ``TaskSeq-pick sad path raises KeyNotFoundException variant`` () = task {
-    fun () ->
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.pick (fun x -> if x = 51 then Some x else None) // dummy tasks sequence ends at 50
-        |> Task.ignore
-
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-[<Fact>]
-let ``TaskSeq-pickAsync sad path raises KeyNotFoundException variant`` () = task {
-    fun () ->
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.pickAsync (fun x -> task { return if x = 51 then Some x else None }) // dummy tasks sequence ends at 50
-        |> Task.ignore
-
-    |> should throwAsyncExact typeof<KeyNotFoundException>
-}
-
-
-[<Fact>]
-let ``TaskSeq-pick happy path middle of seq`` () = task {
-    let! twentyFive =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.pick (fun x -> if x < 26 && x > 24 then Some "foo" else None)
-
-    twentyFive |> should equal "foo"
-}
-
-[<Fact>]
-let ``TaskSeq-pickAsync happy path middle of seq`` () = task {
-    let! twentyFive =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.pickAsync (fun x -> task { return if x < 26 && x > 24 then Some "foo" else None })
-
-    twentyFive |> should equal "foo"
-}
-
-[<Fact>]
-let ``TaskSeq-pick happy path first item of seq`` () = task {
-    let! first =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.pick (fun x -> if x = 1 then Some $"first{x}" else None) // dummy tasks seq starts at 1
-
-    first |> should equal "first1"
-}
-
-[<Fact>]
-let ``TaskSeq-pickAsync happy path first item of seq`` () = task {
-    let! first =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.pickAsync (fun x -> task { return if x = 1 then Some $"first{x}" else None }) // dummy tasks seq starts at 1
-
-    first |> should equal "first1"
-}
-
-[<Fact>]
-let ``TaskSeq-pick happy path last item of seq`` () = task {
-    let! last =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.pick (fun x -> if x = 50 then Some $"last{x}" else None) // dummy tasks seq ends at 50
-
-    last |> should equal "last50"
-}
-
-[<Fact>]
-let ``TaskSeq-pickAsync happy path last item of seq`` () = task {
-    let! last =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.pickAsync (fun x -> task { return if x = 50 then Some $"last{x}" else None }) // dummy tasks seq ends at 50
-
-    last |> should equal "last50"
-}
-
-//
 // TaskSeq.tryPick
 // TaskSeq.tryPickAsync
 //
 
-[<Fact>]
-let ``TaskSeq-tryPick on an empty sequence returns None`` () = task {
-    let! nothing =
-        TaskSeq.empty
-        |> TaskSeq.tryPick (fun x -> if x = 12 then Some x else None)
-
-    nothing |> should be None'
-}
-
-[<Fact>]
-let ``TaskSeq-tryPickAsync on an empty sequence returns None`` () = task {
-    let! nothing =
-        TaskSeq.empty
-        |> TaskSeq.tryPickAsync (fun x -> task { return if x = 12 then Some x else None })
-
-    nothing |> should be None'
-}
-
-[<Fact>]
-let ``TaskSeq-tryPick sad path returns None`` () = task {
-    let! nothing =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryPick (fun x -> if x = 0 then Some x else None) // dummy tasks sequence starts at 1
-
-    nothing |> should be None'
-}
-
-[<Fact>]
-let ``TaskSeq-tryPickAsync sad path return None`` () = task {
-    let! nothing =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryPickAsync (fun x -> task { return if x = 0 then Some x else None }) // dummy tasks sequence starts at 1
-
-    nothing |> should be None'
-}
-
-[<Fact>]
-let ``TaskSeq-tryPick sad path returns None variant`` () = task {
-    let! nothing =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryPick (fun x -> if x >= 51 then Some x else None) // dummy tasks sequence ends at 50 (inverted sign in lambda!)
-
-    nothing |> should be None'
-}
-
-[<Fact>]
-let ``TaskSeq-tryPickAsync sad path return None - variant`` () = task {
-    let! nothing =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryPickAsync (fun x -> task { return if x >= 51 then Some x else None }) // dummy tasks sequence ends at 50
-
-    nothing |> should be None'
-}
+let picker equalTo x = if x = equalTo then Some x else None
+let pickerAsync equalTo x = task { return if x = equalTo then Some x else None }
 
 
-[<Fact>]
-let ``TaskSeq-tryPick happy path middle of seq`` () = task {
-    let! twentyFive =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryPick (fun x -> if x < 26 && x > 24 then Some $"foo{x}" else None)
+module EmptySeq =
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-pick on an empty sequence raises KeyNotFoundException`` variant = task {
+        fun () ->
+            Gen.getEmptyVariant variant
+            |> TaskSeq.pick (fun x -> if x = 12 then Some x else None)
+            |> Task.ignore
+        |> should throwAsyncExact typeof<KeyNotFoundException>
+    }
 
-    twentyFive |> should be Some'
-    twentyFive |> should equal (Some "foo25")
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-pickAsync on an empty sequence raises KeyNotFoundException`` variant = task {
+        fun () ->
+            Gen.getEmptyVariant variant
+            |> TaskSeq.pickAsync (fun x -> task { return if x = 12 then Some x else None })
+            |> Task.ignore
+        |> should throwAsyncExact typeof<KeyNotFoundException>
+    }
 
-[<Fact>]
-let ``TaskSeq-tryPickAsync happy path middle of seq`` () = task {
-    let! twentyFive =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryPickAsync (fun x -> task { return if x < 26 && x > 24 then Some $"foo{x}" else None })
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-tryPick on an empty sequence returns None`` variant = task {
+        let! nothing =
+            Gen.getEmptyVariant variant
+            |> TaskSeq.tryPick (fun x -> if x = 12 then Some x else None)
 
-    twentyFive |> should be Some'
-    twentyFive |> should equal (Some "foo25")
-}
+        nothing |> should be None'
+    }
 
-[<Fact>]
-let ``TaskSeq-tryPick happy path first item of seq`` () = task {
-    let! first =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryPick (sprintf "foo%i" >> Some) // dummy tasks seq starts at 1
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-tryPickAsync on an empty sequence returns None`` variant = task {
+        let! nothing =
+            Gen.getEmptyVariant variant
+            |> TaskSeq.tryPickAsync (fun x -> task { return if x = 12 then Some x else None })
 
-    first |> should be Some'
-    first |> should equal (Some "foo1")
-}
+        nothing |> should be None'
+    }
 
-[<Fact>]
-let ``TaskSeq-tryPickAsync happy path first item of seq`` () = task {
-    let! first =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryPickAsync (fun x -> task { return (sprintf "foo%i" >> Some) x }) // dummy tasks seq starts at 1
+module Immutable =
 
-    first |> should be Some'
-    first |> should equal (Some "foo1")
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-pick sad path raises KeyNotFoundException`` variant = task {
+        fun () ->
+            Gen.getSeqImmutable variant
+            |> TaskSeq.pick (fun x -> if x = 0 then Some x else None) // dummy tasks sequence starts at 1
+            |> Task.ignore
 
-[<Fact>]
-let ``TaskSeq-tryPick happy path last item of seq`` () = task {
-    let! last =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryPick (fun x -> if x = 50 then Some $"foo{x}" else None) // dummy tasks seq ends at 50
+        |> should throwAsyncExact typeof<KeyNotFoundException>
+    }
 
-    last |> should be Some'
-    last |> should equal (Some "foo50")
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-pickAsync sad path raises KeyNotFoundException`` variant = task {
+        fun () ->
+            Gen.getSeqImmutable variant
+            |> TaskSeq.pickAsync (fun x -> task { return if x < 0 then Some x else None }) // dummy tasks sequence starts at 1
+            |> Task.ignore
 
-[<Fact>]
-let ``TaskSeq-tryPickAsync happy path last item of seq`` () = task {
-    let! last =
-        Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
-        |> TaskSeq.tryPickAsync (fun x -> task { return if x = 50 then Some $"foo{x}" else None }) // dummy tasks seq ends at 50
+        |> should throwAsyncExact typeof<KeyNotFoundException>
+    }
 
-    last |> should be Some'
-    last |> should equal (Some "foo50")
-}
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-pick sad path raises KeyNotFoundException variant`` variant = task {
+        fun () ->
+            Gen.getSeqImmutable variant
+            |> TaskSeq.pick (fun x -> if x = 11 then Some x else None) // dummy tasks sequence ends at 50
+            |> Task.ignore
+
+        |> should throwAsyncExact typeof<KeyNotFoundException>
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-pickAsync sad path raises KeyNotFoundException variant`` variant = task {
+        fun () ->
+            Gen.getSeqImmutable variant
+            |> TaskSeq.pickAsync (fun x -> task { return if x = 11 then Some x else None }) // dummy tasks sequence ends at 50
+            |> Task.ignore
+
+        |> should throwAsyncExact typeof<KeyNotFoundException>
+    }
+
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-pick happy path middle of seq`` variant = task {
+        let! twentyFive =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.pick (fun x -> if x < 6 && x > 4 then Some "foo" else None)
+
+        twentyFive |> should equal "foo"
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-pickAsync happy path middle of seq`` variant = task {
+        let! twentyFive =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.pickAsync (fun x -> task { return if x < 6 && x > 4 then Some "foo" else None })
+
+        twentyFive |> should equal "foo"
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-pick happy path first item of seq`` variant = task {
+        let! first =
+            Gen.sideEffectTaskSeqMicro 50L<µs> 1000L<µs> 50
+            |> TaskSeq.pick (fun x -> if x = 1 then Some $"first{x}" else None) // dummy tasks seq starts at 1
+
+        first |> should equal "first1"
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-pickAsync happy path first item of seq`` variant = task {
+        let! first =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.pickAsync (fun x -> task { return if x = 1 then Some $"first{x}" else None }) // dummy tasks seq starts at 1
+
+        first |> should equal "first1"
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-pick happy path last item of seq`` variant = task {
+        let! last =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.pick (fun x -> if x = 10 then Some $"last{x}" else None) // dummy tasks seq ends at 50
+
+        last |> should equal "last10"
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-pickAsync happy path last item of seq`` variant = task {
+        let! last =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.pickAsync (fun x -> task { return if x = 10 then Some $"last{x}" else None }) // dummy tasks seq ends at 50
+
+        last |> should equal "last10"
+    }
+
+    //
+    //
+    // tryXXX stuff
+    //      |
+    //      |
+    //      V
+
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryPick sad path returns None`` variant = task {
+        let! nothing =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.tryPick (fun x -> if x = 0 then Some x else None) // dummy tasks sequence starts at 1
+
+        nothing |> should be None'
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryPickAsync sad path return None`` variant = task {
+        let! nothing =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.tryPickAsync (fun x -> task { return if x = 0 then Some x else None }) // dummy tasks sequence starts at 1
+
+        nothing |> should be None'
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryPick sad path returns None variant`` variant = task {
+        let! nothing =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.tryPick (fun x -> if x >= 11 then Some x else None) // dummy tasks sequence ends at 50 (inverted sign in lambda!)
+
+        nothing |> should be None'
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryPickAsync sad path return None - variant`` variant = task {
+        let! nothing =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.tryPickAsync (fun x -> task { return if x >= 11 then Some x else None }) // dummy tasks sequence ends at 50
+
+        nothing |> should be None'
+    }
+
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryPick happy path middle of seq`` variant = task {
+        let! twentyFive =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.tryPick (fun x -> if x < 6 && x > 4 then Some $"foo{x}" else None)
+
+        twentyFive |> should equal (Some "foo5")
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryPickAsync happy path middle of seq`` variant = task {
+        let! twentyFive =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.tryPickAsync (fun x -> task { return if x < 6 && x > 4 then Some $"foo{x}" else None })
+
+        twentyFive |> should equal (Some "foo5")
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryPick happy path first item of seq`` variant = task {
+        let! first =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.tryPick (sprintf "foo%i" >> Some) // dummy tasks seq starts at 1
+
+        first |> should equal (Some "foo1")
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryPickAsync happy path first item of seq`` variant = task {
+        let! first =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.tryPickAsync (fun x -> task { return (sprintf "foo%i" >> Some) x }) // dummy tasks seq starts at 1
+
+        first |> should equal (Some "foo1")
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryPick happy path last item of seq`` variant = task {
+        let! last =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.tryPick (fun x -> if x = 10 then Some $"foo{x}" else None) // dummy tasks seq ends at 50
+
+        last |> should equal (Some "foo10")
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-tryPickAsync happy path last item of seq`` variant = task {
+        let! last =
+            Gen.getSeqImmutable variant
+            |> TaskSeq.tryPickAsync (fun x -> task { return if x = 10 then Some $"foo{x}" else None }) // dummy tasks seq ends at 50
+
+        last |> should equal (Some "foo10")
+    }
+
+
+module SideEffects =
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-pick KeyNotFoundException only sometimes for mutated state`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+
+        // first: error, item is not there
+        fun () -> TaskSeq.pick (picker 11) ts |> Task.ignore
+        |> should throwAsyncExact typeof<KeyNotFoundException>
+
+        // pick again: no error, because of side effects
+        let! found = TaskSeq.pick (picker 11) ts
+        found |> should equal 11
+
+        // pick once more: error, item is not there anymore.
+        fun () -> TaskSeq.pick (picker 11) ts |> Task.ignore
+        |> should throwAsyncExact typeof<KeyNotFoundException>
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-pickAsync KeyNotFoundException only sometimes for mutated state`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+        
+        // first: error, item is not there
+        fun () -> TaskSeq.pickAsync (pickerAsync 11) ts |> Task.ignore
+        |> should throwAsyncExact typeof<KeyNotFoundException>
+
+        // pick again: no error, because of side effects
+        let! found = TaskSeq.pickAsync (pickerAsync 11) ts
+        found |> should equal 11
+
+        // pick once more: error, item is not there anymore.
+        fun () -> TaskSeq.pickAsync (pickerAsync 11) ts |> Task.ignore
+        |> should throwAsyncExact typeof<KeyNotFoundException>
+    }
+
+    [<Fact>]
+    let ``TaskSeq-pick _specialcase_ prove we don't read past the found item`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                i <- i + 1
+                yield i
+        }
+
+        let! found = ts |> TaskSeq.pick (picker 3)
+        found |> should equal 3
+        i |> should equal 3 // only partial evaluation!
+
+        // pick next item. We do get a new iterator, but mutable state is now starting at '3'
+        let! found = ts |> TaskSeq.pick (picker 4)
+        found |> should equal 4
+        i |> should equal 4 // only partial evaluation!
+    }
+
+    [<Fact>]
+    let ``TaskSeq-pickAsync _specialcase_ prove we don't read past the found item`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                i <- i + 1
+                yield i
+        }
+
+        let! found = ts |> TaskSeq.pickAsync (pickerAsync 3)
+        found |> should equal 3
+        i |> should equal 3 // only partial evaluation!
+
+        // pick next item. We do get a new iterator, but mutable state is now starting at '3'
+        let! found = ts |> TaskSeq.pickAsync (pickerAsync 4)
+        found |> should equal 4
+        i |> should equal 4
+    }
+
+    [<Fact>]
+    let ``TaskSeq-pick _specialcase_ prove we don't read past the found item v2`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            yield 42
+            i <- i + 1
+            i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.pick (picker 42)
+        found |> should equal 42
+        i |> should equal 0 // because no MoveNext after found item, the last statements are not executed
+    }
+
+    [<Fact>]
+    let ``TaskSeq-pickAsync _specialcase_ prove we don't read past the found item v2`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            yield 42
+            i <- i + 1
+            i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.pickAsync (pickerAsync 42 )
+        found |> should equal 42
+        i |> should equal 0 // because no MoveNext after found item, the last statements are not executed
+    }
+
+    [<Fact>]
+    let ``TaskSeq-pick _specialcase_ prove statement after yield is not evaluated`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                yield i
+                i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.pick (picker 0)
+        found |> should equal 0
+        i |> should equal 0 // notice that it should be one higher if the statement after 'yield' is evaluated
+
+        // pick some next item. We do get a new iterator, but mutable state is now starting at '1'
+        let! found = ts |> TaskSeq.pick (picker 4)
+        found |> should equal 4
+        i |> should equal 4 // only partial evaluation!
+    }
+
+    [<Fact>]
+    let ``TaskSeq-pickAsync _specialcase_ prove statement after yield is not evaluated`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                yield i
+                i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.pickAsync (pickerAsync 0 )
+        found |> should equal 0
+        i |> should equal 0 // notice that it should be one higher if the statement after 'yield' is evaluated
+
+        // pick some next item. We do get a new iterator, but mutable state is now starting at '1'
+        let! found = ts |> TaskSeq.pickAsync (pickerAsync 4 )
+        found |> should equal 4
+        i |> should equal 4 // only partial evaluation!
+    }
+
+
+    //
+    //
+    // tryXXX stuff
+    //      |
+    //      |
+    //      V
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-tryPick KeyNotFoundException only sometimes for mutated state`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+        let picker x = if x = 11 then Some x else None
+
+        // first: None
+        let! found = TaskSeq.tryPick picker ts
+        found |> should be None'
+
+        // pick again: found now, because of side effects
+        let! found = TaskSeq.tryPick picker ts
+        found |> should equal (Some 11)
+
+        // pick once more: None
+        let! found = TaskSeq.tryPick picker ts
+        found |> should be None'
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-tryPickAsync KeyNotFoundException only sometimes for mutated state`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+        let picker x = task { return if x = 11 then Some x else None }
+
+        // first: None
+        let! found = TaskSeq.tryPickAsync picker ts
+        found |> should be None'
+
+        // pick again: found now, because of side effects
+        let! found = TaskSeq.tryPickAsync picker ts
+        found |> should equal (Some 11)
+
+        // pick once more: None
+        let! found = TaskSeq.tryPickAsync picker ts
+        found |> should be None'
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryPick _specialcase_ prove we don't read past the found item`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                i <- i + 1
+                yield i
+        }
+
+        let! found = ts |> TaskSeq.tryPick (picker 3)
+        found |> should equal (Some 3)
+        i |> should equal 3 // only partial evaluation!
+
+        // pick next item. We do get a new iterator, but mutable state is now starting at '3'
+        let! found = ts |> TaskSeq.tryPick (picker 4)
+        found |> should equal (Some 4)
+        i |> should equal 4 // only partial evaluation!
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryPickAsync _specialcase_ prove we don't read past the found item`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                i <- i + 1
+                yield i
+        }
+
+        let! found = ts |> TaskSeq.tryPickAsync (pickerAsync 3)
+        found |> should equal (Some 3)
+        i |> should equal 3 // only partial evaluation!
+
+        // pick next item. We do get a new iterator, but mutable state is now starting at '3'
+        let! found = ts |> TaskSeq.tryPickAsync (pickerAsync 4)
+        found |> should equal (Some 4)
+        i |> should equal 4
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryPick _specialcase_ prove we don't read past the found item v2`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            yield 42
+            i <- i + 1
+            i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.tryPick (picker 42)
+        found |> should equal (Some 42)
+        i |> should equal 0 // because no MoveNext after found item, the last statements are not executed
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryPickAsync _specialcase_ prove we don't read past the found item v2`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            yield 42
+            i <- i + 1
+            i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.tryPickAsync (pickerAsync 42)
+        found |> should equal (Some 42)
+        i |> should equal 0 // because no MoveNext after found item, the last statements are not executed
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryPick _specialcase_ prove statement after yield is not evaluated`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                yield i
+                i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.tryPick (picker 0)
+        found |> should equal (Some 0)
+        i |> should equal 0 // notice that it should be one higher if the statement after 'yield' is evaluated
+
+        // pick some next item. We do get a new iterator, but mutable state is now starting at '1'
+        let! found = ts |> TaskSeq.tryPick (picker 4)
+        found |> should equal (Some 4)
+        i |> should equal 4 // only partial evaluation!
+    }
+
+    [<Fact>]
+    let ``TaskSeq-tryPickAsync _specialcase_ prove statement after yield is not evaluated`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                yield i
+                i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.tryPickAsync (pickerAsync 0)
+        found |> should equal (Some 0)
+        i |> should equal 0 // notice that it should be one higher if the statement after 'yield' is evaluated
+
+        // pick some next item. We do get a new iterator, but mutable state is now starting at '1'
+        let! found = ts |> TaskSeq.tryPickAsync (pickerAsync 4)
+        found |> should equal (Some 4)
+        i |> should equal 4 // only partial evaluation!
+    }

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
@@ -20,68 +20,192 @@ open System.Collections.Generic
 ///                                                                      ///
 ////////////////////////////////////////////////////////////////////////////
 
-[<Fact>]
-let ``TaskSeq-toArrayAsync should succeed`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let! (results: _[]) = tq |> TaskSeq.toArrayAsync
-    results |> should equal [| 1..10 |]
-}
+module EmptySeq =
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-toArrayAsync with empty`` variant = task {
+        let tq = Gen.getEmptyVariant variant
+        let! (results: _[]) = tq |> TaskSeq.toArrayAsync
+        results |> should be Empty
+    }
 
-[<Fact>]
-let ``TaskSeq-toArrayAsync can be applied multiple times to the same sequence`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let! (results1: _[]) = tq |> TaskSeq.toArrayAsync
-    let! (results2: _[]) = tq |> TaskSeq.toArrayAsync
-    let! (results3: _[]) = tq |> TaskSeq.toArrayAsync
-    let! (results4: _[]) = tq |> TaskSeq.toArrayAsync
-    results1 |> should equal [| 1..10 |]
-    results2 |> should equal [| 11..20 |]
-    results3 |> should equal [| 21..30 |]
-    results4 |> should equal [| 31..40 |]
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-toListAsync with empty`` variant = task {
+        let tq = Gen.getEmptyVariant variant
+        let! (results: list<_>) = tq |> TaskSeq.toListAsync
+        results |> should be Empty
+    }
 
-[<Fact>]
-let ``TaskSeq-toListAsync should succeed`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let! (results: list<_>) = tq |> TaskSeq.toListAsync
-    results |> should equal [ 1..10 ]
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-toSeqCachedAsync with empty`` variant = task {
+        let tq = Gen.getEmptyVariant variant
+        let! (results: seq<_>) = tq |> TaskSeq.toSeqCachedAsync
+        results |> Seq.toArray |> should be Empty
+    }
 
-[<Fact>]
-let ``TaskSeq-toSeqCachedAsync should succeed`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let! (results: seq<_>) = tq |> TaskSeq.toSeqCachedAsync
-    results |> Seq.toArray |> should equal [| 1..10 |]
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-toIListAsync with empty`` variant = task {
+        let tq = Gen.getEmptyVariant variant
+        let! (results: IList<_>) = tq |> TaskSeq.toIListAsync
+        results |> Seq.toArray |> should be Empty
+    }
 
-[<Fact>]
-let ``TaskSeq-toIListAsync should succeed`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let! (results: IList<_>) = tq |> TaskSeq.toIListAsync
-    results |> Seq.toArray |> should equal [| 1..10 |]
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-toResizeArray with empty`` variant = task {
+        let tq = Gen.getEmptyVariant variant
+        let! (results: ResizeArray<_>) = tq |> TaskSeq.toResizeArrayAsync
+        results |> Seq.toArray |> should be Empty
+    }
 
-[<Fact>]
-let ``TaskSeq-toResizeArray should succeed`` () = task {
-    let tq = Gen.sideEffectTaskSeq 10
-    let! (results: ResizeArray<_>) = tq |> TaskSeq.toResizeArrayAsync
-    results |> Seq.toArray |> should equal [| 1..10 |]
-}
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-toArray with empty`` variant =
+        let tq = Gen.getEmptyVariant variant
+        let (results: _[]) = tq |> TaskSeq.toArray
+        results |> should be Empty
 
-[<Fact>]
-let ``TaskSeq-toArray should succeed and be blocking`` () =
-    let tq = Gen.sideEffectTaskSeq 10
-    let (results: _[]) = tq |> TaskSeq.toArray
-    results |> should equal [| 1..10 |]
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-toList with empty`` variant =
+        let tq = Gen.getEmptyVariant variant
+        let (results: list<_>) = tq |> TaskSeq.toList
+        results |> should be Empty
 
-[<Fact>]
-let ``TaskSeq-toList should succeed and be blocking`` () =
-    let tq = Gen.sideEffectTaskSeq 10
-    let (results: list<_>) = tq |> TaskSeq.toList
-    results |> should equal [ 1..10 ]
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-toSeqCached with empty`` variant =
+        let tq = Gen.getEmptyVariant variant
+        let (results: seq<_>) = tq |> TaskSeq.toSeqCached
+        results |> Seq.toArray |> should be Empty
 
-[<Fact>]
-let ``TaskSeq-toSeqCached should succeed and be blocking`` () =
-    let tq = Gen.sideEffectTaskSeq 10
-    let (results: seq<_>) = tq |> TaskSeq.toSeqCached
-    results |> Seq.toArray |> should equal [| 1..10 |]
+module Immutable =
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-toArrayAsync should succeed`` variant = task {
+        let tq = Gen.getSeqImmutable variant
+        let! (results: _[]) = tq |> TaskSeq.toArrayAsync
+        results |> should equal [| 1..10 |]
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-toListAsync should succeed`` variant = task {
+        let tq = Gen.getSeqImmutable variant
+        let! (results: list<_>) = tq |> TaskSeq.toListAsync
+        results |> should equal [ 1..10 ]
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-toSeqCachedAsync should succeed`` variant = task {
+        let tq = Gen.getSeqImmutable variant
+        let! (results: seq<_>) = tq |> TaskSeq.toSeqCachedAsync
+        results |> Seq.toArray |> should equal [| 1..10 |]
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-toIListAsync should succeed`` variant = task {
+        let tq = Gen.getSeqImmutable variant
+        let! (results: IList<_>) = tq |> TaskSeq.toIListAsync
+        results |> Seq.toArray |> should equal [| 1..10 |]
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-toResizeArray should succeed`` variant = task {
+        let tq = Gen.getSeqImmutable variant
+        let! (results: ResizeArray<_>) = tq |> TaskSeq.toResizeArrayAsync
+        results |> Seq.toArray |> should equal [| 1..10 |]
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-toArray should succeed and be blocking`` variant =
+        let tq = Gen.getSeqImmutable variant
+        let (results: _[]) = tq |> TaskSeq.toArray
+        results |> should equal [| 1..10 |]
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-toList should succeed and be blocking`` variant =
+        let tq = Gen.getSeqImmutable variant
+        let (results: list<_>) = tq |> TaskSeq.toList
+        results |> should equal [ 1..10 ]
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-toSeqCached should succeed and be blocking`` variant =
+        let tq = Gen.getSeqImmutable variant
+        let (results: seq<_>) = tq |> TaskSeq.toSeqCached
+        results |> Seq.toArray |> should equal [| 1..10 |]
+
+
+module SideEffects =
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-toArrayAsync should execute side effects multiple times`` variant = task {
+        let tq = Gen.getSeqWithSideEffect variant
+        let! (results1: _[]) = tq |> TaskSeq.toArrayAsync
+        let! (results2: _[]) = tq |> TaskSeq.toArrayAsync
+        results1 |> should equal [| 1..10 |]
+        results2 |> should equal [| 11..20 |]
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-toArrayAsync can be applied multiple times to the same sequence`` variant = task {
+        let tq = Gen.getSeqWithSideEffect variant
+        let! (results1: _[]) = tq |> TaskSeq.toArrayAsync
+        let! (results2: _[]) = tq |> TaskSeq.toArrayAsync
+        results1 |> should equal [| 1..10 |]
+        results2 |> should equal [| 11..20 |]
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-toListAsync should execute side effects multiple times`` variant = task {
+        let tq = Gen.sideEffectTaskSeq 10
+        let! (results1: list<_>) = tq |> TaskSeq.toListAsync
+        let! (results2: list<_>) = tq |> TaskSeq.toListAsync
+        results1 |> should equal [ 1..10 ]
+        results2 |> should equal [ 11..20 ]
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-toSeqCachedAsync should execute side effects multiple times`` variant = task {
+        let tq = Gen.getSeqWithSideEffect variant
+        let! (results1: seq<_>) = tq |> TaskSeq.toSeqCachedAsync
+        let! (results2: seq<_>) = tq |> TaskSeq.toSeqCachedAsync
+        results1 |> Seq.toArray |> should equal [| 1..10 |]
+        results2 |> Seq.toArray |> should equal [| 11..20 |]
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-toIListAsync should execute side effects multiple times`` variant = task {
+        let tq = Gen.getSeqWithSideEffect variant
+        let! (results1: IList<_>) = tq |> TaskSeq.toIListAsync
+        let! (results2: IList<_>) = tq |> TaskSeq.toIListAsync
+        results1 |> Seq.toArray |> should equal [| 1..10 |]
+        results2 |> Seq.toArray |> should equal [| 11..20 |]
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-toResizeArray should execute side effects multiple times`` variant = task {
+        let tq = Gen.getSeqWithSideEffect variant
+        let! (results1: ResizeArray<_>) = tq |> TaskSeq.toResizeArrayAsync
+        let! (results2: ResizeArray<_>) = tq |> TaskSeq.toResizeArrayAsync
+        results1 |> Seq.toArray |> should equal [| 1..10 |]
+        results2 |> Seq.toArray |> should equal [| 11..20 |]
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-toArray should execute side effects multiple times`` variant =
+        let tq = Gen.getSeqWithSideEffect variant
+        let (results1: _[]) = tq |> TaskSeq.toArray
+        let (results2: _[]) = tq |> TaskSeq.toArray
+        results1 |> should equal [| 1..10 |]
+        results2 |> should equal [| 11..20 |]
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-toList should execute side effects multiple times`` variant =
+        let tq = Gen.getSeqWithSideEffect variant
+        let (results1: list<_>) = tq |> TaskSeq.toList
+        let (results2: list<_>) = tq |> TaskSeq.toList
+        results1 |> should equal [ 1..10 ]
+        results2 |> should equal [ 11..20 ]
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-toSeqCached should execute side effects multiple times`` variant =
+        let tq = Gen.getSeqWithSideEffect variant
+        let (results1: seq<_>) = tq |> TaskSeq.toSeqCached
+        let (results2: seq<_>) = tq |> TaskSeq.toSeqCached
+        results1 |> Seq.toArray |> should equal [| 1..10 |]
+        results2 |> Seq.toArray |> should equal [| 11..20 |]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
@@ -7,6 +7,10 @@ open FsToolkit.ErrorHandling
 
 open FSharpy
 
+//
+// TaskSeq.zip
+//
+
 [<Fact>]
 let ``TaskSeq-zip zips in correct order`` () = task {
     let one = Gen.sideEffectTaskSeq 10

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
@@ -11,106 +11,153 @@ open FSharpy
 // TaskSeq.zip
 //
 
-[<Fact>]
-let ``TaskSeq-zip zips in correct order`` () = task {
-    let one = Gen.sideEffectTaskSeq 10
-    let two = Gen.sideEffectTaskSeq 10
-    let combined = TaskSeq.zip one two
-    let! combined = TaskSeq.toArrayAsync combined
+module EmptySeq =
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-zip can zip empty sequences v1`` variant =
+        TaskSeq.zip (Gen.getEmptyVariant variant) (Gen.getEmptyVariant variant)
+        |> verifyEmpty
 
-    combined
-    |> Array.forall (fun (x, y) -> x = y)
-    |> should be True
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-zip can zip empty sequences v2`` variant =
+        TaskSeq.zip TaskSeq.empty<int> (Gen.getEmptyVariant variant)
+        |> verifyEmpty
 
-    combined |> should be (haveLength 10)
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-zip can zip empty sequences v3`` variant =
+        TaskSeq.zip (Gen.getEmptyVariant variant) TaskSeq.empty<int>
+        |> verifyEmpty
 
-    combined
-    |> should equal (Array.init 10 (fun x -> x + 1, x + 1))
-}
 
-[<Fact>]
-let ``TaskSeq-zip zips in correct order for differently delayed sequences`` () = task {
-    let one = Gen.sideEffectTaskSeq_Sequential 10
-    let two = Gen.sideEffectTaskSeq 10
-    let combined = TaskSeq.zip one two
-    let! combined = TaskSeq.toArrayAsync combined
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-zip zips in correct order`` variant = task {
+        let one = Gen.getSeqImmutable variant
+        let two = Gen.getSeqImmutable variant
+        let combined = TaskSeq.zip one two
+        let! combined = TaskSeq.toArrayAsync combined
 
-    combined
-    |> Array.forall (fun (x, y) -> x = y)
-    |> should be True
+        combined
+        |> Array.forall (fun (x, y) -> x = y)
+        |> should be True
 
-    combined |> should be (haveLength 10)
+        combined |> should be (haveLength 10)
 
-    combined
-    |> should equal (Array.init 10 (fun x -> x + 1, x + 1))
-}
-
-[<Theory; InlineData 100; InlineData 1_000; InlineData 10_000; InlineData 100_000>]
-let ``TaskSeq-zip zips large sequences just fine`` length = task {
-    let one = Gen.sideEffectTaskSeqMicro 10L<µs> 50L<µs> length
-    let two = Gen.sideEffectTaskSeq_Sequential length
-    let combined = TaskSeq.zip one two
-    let! combined = TaskSeq.toArrayAsync combined
-
-    combined
-    |> Array.forall (fun (x, y) -> x = y)
-    |> should be True
-
-    combined |> should be (haveLength length)
-    combined |> Array.last |> should equal (length, length)
-}
-
-[<Fact>]
-let ``TaskSeq-zip zips different types`` () = task {
-    let one = taskSeq {
-        yield "one"
-        yield "two"
+        combined
+        |> should equal (Array.init 10 (fun x -> x + 1, x + 1))
     }
 
-    let two = taskSeq {
-        yield 42L
-        yield 43L
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-zip zips in correct order for differently delayed sequences`` variant = task {
+        let one = Gen.getSeqImmutable variant
+        let two = taskSeq { yield! [ 1..10 ] }
+        let combined = TaskSeq.zip one two
+        let! combined = TaskSeq.toArrayAsync combined
+
+        combined
+        |> Array.forall (fun (x, y) -> x = y)
+        |> should be True
+
+        combined |> should be (haveLength 10)
+
+        combined
+        |> should equal (Array.init 10 (fun x -> x + 1, x + 1))
     }
 
-    let combined = TaskSeq.zip one two
-    let! combined = TaskSeq.toArrayAsync combined
+module SideEffects =
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-zip zips can deal with side effects in sequences`` variant = task {
+        let one = Gen.getSeqWithSideEffect variant
+        let two = Gen.getSeqWithSideEffect variant
+        let combined = TaskSeq.zip one two
+        let! combined = TaskSeq.toArrayAsync combined
 
-    combined |> should equal [| ("one", 42L); ("two", 43L) |]
-}
+        combined
+        |> Array.forall (fun (x, y) -> x = y)
+        |> should be True
 
-[<Theory; InlineData true; InlineData false>]
-let ``TaskSeq-zip throws on unequal lengths, variant`` leftThrows = task {
-    let long = Gen.sideEffectTaskSeq 11
-    let short = Gen.sideEffectTaskSeq 10
+        combined |> should be (haveLength 10)
 
-    let combined =
-        if leftThrows then
-            TaskSeq.zip short long
-        else
-            TaskSeq.zip long short
+        combined
+        |> should equal (Array.init 10 (fun x -> x + 1, x + 1))
+    }
 
-    fun () -> TaskSeq.toArrayAsync combined |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-zip zips combine a side-effect-free, and a side-effect-full sequence`` variant = task {
+        let one = Gen.getSeqWithSideEffect variant
+        let two = taskSeq { yield! [ 1..10 ] }
+        let combined = TaskSeq.zip one two
+        let! combined = TaskSeq.toArrayAsync combined
 
-[<Theory; InlineData true; InlineData false>]
-let ``TaskSeq-zip throws on unequal lengths with empty seq`` leftThrows = task {
-    let one = Gen.sideEffectTaskSeq 1
+        combined
+        |> Array.forall (fun (x, y) -> x = y)
+        |> should be True
 
-    let combined =
-        if leftThrows then
-            TaskSeq.zip TaskSeq.empty one
-        else
-            TaskSeq.zip one TaskSeq.empty
+        combined |> should be (haveLength 10)
 
-    fun () -> TaskSeq.toArrayAsync combined |> Task.ignore
-    |> should throwAsyncExact typeof<ArgumentException>
-}
+        combined
+        |> should equal (Array.init 10 (fun x -> x + 1, x + 1))
+    }
 
-[<Fact>]
-let ``TaskSeq-zip can zip empty arrays`` () = task {
-    let combined = TaskSeq.zip TaskSeq.empty<int> TaskSeq.empty<string>
-    let! combined = TaskSeq.toArrayAsync combined
-    combined |> should be Empty
-    Array.isEmpty combined |> should be True
-}
+module Performance =
+    [<Theory; InlineData 100; InlineData 1_000; InlineData 10_000; InlineData 100_000>]
+    let ``TaskSeq-zip zips large sequences just fine`` length = task {
+        let one = Gen.sideEffectTaskSeqMicro 10L<µs> 50L<µs> length
+        let two = Gen.sideEffectTaskSeq_Sequential length
+        let combined = TaskSeq.zip one two
+        let! combined = TaskSeq.toArrayAsync combined
+
+        combined
+        |> Array.forall (fun (x, y) -> x = y)
+        |> should be True
+
+        combined |> should be (haveLength length)
+        combined |> Array.last |> should equal (length, length)
+    }
+
+module Other =
+    [<Fact>]
+    let ``TaskSeq-zip zips different types`` () = task {
+        let one = taskSeq {
+            yield "one"
+            yield "two"
+        }
+
+        let two = taskSeq {
+            yield 42L
+            yield 43L
+        }
+
+        let combined = TaskSeq.zip one two
+        let! combined = TaskSeq.toArrayAsync combined
+
+        combined |> should equal [| ("one", 42L); ("two", 43L) |]
+    }
+
+    [<Theory; InlineData true; InlineData false>]
+    let ``TaskSeq-zip throws on unequal lengths, variant`` leftThrows = task {
+        let long = Gen.sideEffectTaskSeq 11
+        let short = Gen.sideEffectTaskSeq 10
+
+        let combined =
+            if leftThrows then
+                TaskSeq.zip short long
+            else
+                TaskSeq.zip long short
+
+        fun () -> TaskSeq.toArrayAsync combined |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }
+
+    [<Theory; InlineData true; InlineData false>]
+    let ``TaskSeq-zip throws on unequal lengths with empty seq`` leftThrows = task {
+        let one = Gen.sideEffectTaskSeq 1
+
+        let combined =
+            if leftThrows then
+                TaskSeq.zip TaskSeq.empty one
+            else
+                TaskSeq.zip one TaskSeq.empty
+
+        fun () -> TaskSeq.toArrayAsync combined |> Task.ignore
+        |> should throwAsyncExact typeof<ArgumentException>
+    }

--- a/src/FSharpy.TaskSeq.Test/TestUtils.fs
+++ b/src/FSharpy.TaskSeq.Test/TestUtils.fs
@@ -302,12 +302,12 @@ module TestUtils =
             match variant with
             | EmptyVariant.CallEmpty -> TaskSeq.empty
             | EmptyVariant.Do -> taskSeq { do ignore () }
-            | EmptyVariant.DoBang -> taskSeq { do! task { return () } } // TODO: this doesn't work with Task, only Task<unit>...
+            | EmptyVariant.DoBang -> taskSeq { do! task { return () } }
             | EmptyVariant.YieldBang -> taskSeq { yield! Seq.empty<int> }
             | EmptyVariant.YieldBangNested -> taskSeq { yield! taskSeq { do ignore () } }
             | EmptyVariant.DelayDoBang -> taskSeq {
-                do! longDelay ()
-                do! longDelay ()
+                do! microDelay ()
+                do! microDelay ()
                 do! longDelay ()
               }
             | EmptyVariant.DelayYieldBang -> taskSeq {
@@ -322,7 +322,7 @@ module TestUtils =
                 yield! taskSeq {
                     do! microDelay ()
                     yield! taskSeq { do! microDelay () }
-                    do! microDelay ()
+                    do! longDelay ()
                 }
 
                 yield! TaskSeq.empty

--- a/src/FSharpy.TaskSeq.Test/TestUtils.fs
+++ b/src/FSharpy.TaskSeq.Test/TestUtils.fs
@@ -136,6 +136,11 @@ type DummyTaskFactory(µsecMin: int64<µs>, µsecMax: int64<µs>) =
 
 [<AutoOpen>]
 module TestUtils =
+    let verifyEmpty ts =
+        ts
+        |> TaskSeq.toSeqCachedAsync
+        |> Task.map (Seq.isEmpty >> should be True)
+
     /// Delays (no spin-wait!) between 20 and 70ms, assuming a 15.6ms resolution clock
     let longDelay () = task { do! Task.Delay(Random().Next(20, 70)) }
 
@@ -195,34 +200,34 @@ module TestUtils =
     // VS test runner will hang, and NCrunch will (properly) show that the type does not implement
     // a default constructor. See https://github.com/xunit/xunit/issues/429, amongst others.
     type EmptyVariant =
-        | CallEmpty = 0
-        | Do = 1
-        | DoBang = 2
-        | YieldBang = 3
-        | YieldBangNested = 4
-        | DelayDoBang = 6
-        | DelayYieldBang = 7
-        | DelayYieldBangNested = 8
+        | CallEmpty = 10
+        | Do = 11
+        | DoBang = 12
+        | YieldBang = 13
+        | YieldBangNested = 14
+        | DelayDoBang = 16
+        | DelayYieldBang = 17
+        | DelayYieldBangNested = 18
 
     type SeqImmutable =
-        | Sequential_YieldBang = 0
-        | Sequential_Yield = 1
-        | Sequential_For = 2
-        | Sequential_Combine = 3
-        | Sequential_Zero = 4
-        | ThreadSpinWait = 5
-        | AsyncYielded = 6
-        | AsyncYielded_Nested = 7
+        | Sequential_YieldBang = 100
+        | Sequential_Yield = 101
+        | Sequential_For = 102
+        | Sequential_Combine = 103
+        | Sequential_Zero = 104
+        | ThreadSpinWait = 105
+        | AsyncYielded = 106
+        | AsyncYielded_Nested = 107
 
     type SeqWithSideEffect =
-        | Sequential_YieldBang = 0
-        | Sequential_Yield = 1
-        | Sequential_For = 2
-        | Sequential_Combine = 3
-        | Sequential_Zero = 4
-        | ThreadSpinWait = 5
-        | AsyncYielded = 6
-        | AsyncYielded_Nested = 7
+        | Sequential_YieldBang = 1000
+        | Sequential_Yield = 1001
+        | Sequential_For = 1002
+        | Sequential_Combine = 1003
+        | Sequential_Zero = 1004
+        | ThreadSpinWait = 1005
+        | AsyncYielded = 1006
+        | AsyncYielded_Nested = 1007
 
     /// Several task generators, with artificial delays,
     /// mostly to ensure sequential async operation of side effects.

--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -147,9 +147,6 @@ and [<AbstractClass; NoEquality; NoComparison>] TaskSeq<'T>() =
 
     abstract MoveNextAsyncResult: unit -> ValueTask<bool>
 
-    /// Initializes the machine data on 'self'
-    abstract InitMachineDataForTailcalls: ct: CancellationToken -> unit
-
     interface IAsyncEnumerator<'T> with
         member _.Current = raiseNotImpl ()
         member _.MoveNextAsync() = raiseNotImpl ()
@@ -185,11 +182,6 @@ and [<NoComparison; NoEquality>] TaskSeq<'Machine, 'T
     /// Keeps the active state machine.
     [<DefaultValue(false)>]
     val mutable _machine: 'Machine
-
-    override this.InitMachineDataForTailcalls(ct) =
-        match this._machine.Data :> obj with
-        | null -> this.InitMachineData(ct, &this._machine)
-        | _ -> ()
 
     member this.InitMachineData(ct, machine: 'Machine byref) =
         let data = TaskSeqStateMachineData()


### PR DESCRIPTION
Just a stepping stone to more coverage. This fills the following gaps:

 - [x] Expands tests for `TaskSeq.choose` and `TaskSeq.chooseAsync`
 - [x] Expands tests for `TaskSeq.exactlyOne/tryExactlyOne`
 - [x] Expands tests for `TaskSeq.filter/filterAsync`
 - [x] Expands tests for `TaskSeq.find/findAsync/tryFind/tryFindAsync`

TODO:
 - [x] Expanding tests for `TaskSeq.collect/collectAsync`
 - [x] Expanding tests for `TaskSeq.fold/foldAsync`
 - [x] Expanding tests for `TaskSeq.head/tryHead`
 - [x] Expanding tests for `TaskSeq.isEmpty`
 - [x] Expanding tests for `TaskSeq.item/tryItem`
 - [x] Expanding tests for `TaskSeq.iter/iterAsync/iteri/iteriAsync` (wrt side effects)
 - [x] Expanding tests for `TaskSeq.map/mapAsync`
 - [x] Expanding tests for `TaskSeq.pick/pickAsync/tryPick/tryPickAsync`
 - [x] Expanding tests for `TaskSeq.zip`
 - [x] Expanding tests for the conversion functions `OfXXX/ToXXX`