### PR TITLE
Fix bug #65, prevent TaskSeq.item and tryItem to read beyond the item it found

### DIFF
--- a/src/FSharpy.TaskSeq/TaskSeqInternal.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqInternal.fs
@@ -297,10 +297,11 @@ module internal TaskSeqInternal =
             while go && idx <= index do
                 if idx = index then
                     foundItem <- Some e.Current
-
-                let! step = e.MoveNextAsync()
-                go <- step
-                idx <- idx + 1
+                    go <- false
+                else
+                    let! step = e.MoveNextAsync()
+                    go <- step
+                    idx <- idx + 1
 
             return foundItem
     }


### PR DESCRIPTION
Fixes: #65 